### PR TITLE
Activate gosec in golangci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -83,6 +83,7 @@ linters:
     - typecheck
     - unused
     - varcheck
+    - gosec
   fast: false
 
 linters-settings:

--- a/pkg/operator/controller/test/vars.go
+++ b/pkg/operator/controller/test/vars.go
@@ -26,7 +26,8 @@ const (
 	TestNamespace     = ""
 	OperandName       = "node-observability-operator"
 	OperatorNamespace = "node-observability-operator"
-	SecretName        = "node-observability-secret"
+	// #nosec G101 -- this is not the secret value actually used
+	SecretName = "node-observability-secret"
 )
 
 var (


### PR DESCRIPTION
* Annotate constant SecretName in vars.go as a false positive
* Fix the false positive that was also highlighted during the audit review