### PR TITLE
CFE-380: Mount Kubelet-serving-ca configmap to the agent daemonset

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get

--- a/pkg/operator/controller/nodeobservability/controller.go
+++ b/pkg/operator/controller/nodeobservability/controller.go
@@ -61,6 +61,7 @@ type NodeObservabilityReconciler struct {
 //+kubebuilder:rbac:groups=core,namespace=node-observability-operator,resources=services,verbs=list;get;create;watch;delete;
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=list;get;create;watch;delete;
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=list;get;watch
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=list;get;
 //+kubebuilder:rbac:groups=core,resources=nodes/proxy,verbs=list;get;
 //+kubebuilder:rbac:urls=/debug/*,verbs=get;

--- a/pkg/operator/controller/nodeobservability/controller_test.go
+++ b/pkg/operator/controller/nodeobservability/controller_test.go
@@ -175,20 +175,20 @@ func TestReconcile(t *testing.T) {
 	}{
 		{
 			name:            "Bootstrapping",
-			existingObjects: []runtime.Object{testNodeObservability()},
+			existingObjects: []runtime.Object{testNodeObservability(), makeKubeletCACM()},
 			inputRequest:    testRequest(),
 			expectedResult:  reconcile.Result{},
 			expectedEvents:  []test.Event{},
 		},
 		{
 			name:            "Deleted",
-			existingObjects: []runtime.Object{},
+			existingObjects: []runtime.Object{makeKubeletCACM()},
 			inputRequest:    testRequest(),
 			expectedResult:  reconcile.Result{},
 		},
 		{
 			name:            "Deleting",
-			existingObjects: []runtime.Object{testNodeObservabilityToBeDeleted()},
+			existingObjects: []runtime.Object{testNodeObservabilityToBeDeleted(), makeKubeletCACM()},
 			inputRequest:    testRequest(),
 			expectedResult:  reconcile.Result{},
 		},


### PR DESCRIPTION
* Updates node-observability-manager-controller RBAC so that it can get configMaps cluster-wide
* Upon creation of the agent daemonset:
  * Uses the KubeClient to get configmap `kubelet-serving-ca` in namespace `openshift-kube-apiserver`
  * Makes a copy of that configmap in `node-observability-operator` namespace, making the owner reference the nodeobservability object
  * Creates the daemonset with the contents of the configmap mounted in `/var/run/secrets/kubernetes.io/serviceaccount/kubelet-serving-ca.crt` 