### PR TITLE
Fix ConditionalStatus of NOMC

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -70,7 +70,7 @@ const (
 )
 
 type ConditionalStatus struct {
-	Conditions []metav1.Condition `json:"conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 func (c *ConditionalStatus) GetCondition(t string) *metav1.Condition {

--- a/api/v1alpha1/nodeobservabilitymachineconfig_types.go
+++ b/api/v1alpha1/nodeobservabilitymachineconfig_types.go
@@ -39,7 +39,7 @@ type NodeObservabilityDebug struct {
 type NodeObservabilityMachineConfigStatus struct {
 	// conditions represents the latest available observations of current operator state.
 	// +optional
-	ConditionalStatus `json:"conditions"`
+	ConditionalStatus `json:",inline,omitempty"`
 
 	// lastReconcile is the time of last reconciliation
 	// +nullable

--- a/bundle/manifests/nodeobservability.olm.openshift.io_nodeobservabilities.yaml
+++ b/bundle/manifests/nodeobservability.olm.openshift.io_nodeobservabilities.yaml
@@ -135,8 +135,6 @@ spec:
                       - type
                       type: object
                     type: array
-                required:
-                - conditions
                 type: object
               count:
                 description: Count is the number of pods (one for each node) the daemon

--- a/bundle/manifests/nodeobservability.olm.openshift.io_nodeobservabilitymachineconfigs.yaml
+++ b/bundle/manifests/nodeobservability.olm.openshift.io_nodeobservabilitymachineconfigs.yaml
@@ -53,83 +53,73 @@ spec:
               state of NodeObservabilityMachineConfig
             properties:
               conditions:
-                description: conditions represents the latest available observations
-                  of current operator state.
-                properties:
-                  conditions:
-                    items:
-                      description: "Condition contains details for one aspect of the
-                        current state of this API Resource. --- This struct is intended
-                        for direct use as an array at the field path .status.conditions.
-                        \ For example, type FooStatus struct{ // Represents the observations
-                        of a foo's current state. // Known .status.conditions.type
-                        are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type
-                        // +patchStrategy=merge // +listType=map // +listMapKey=type
-                        Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                        patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                        \n // other fields }"
-                      properties:
-                        lastTransitionTime:
-                          description: lastTransitionTime is the last time the condition
-                            transitioned from one status to another. This should be
-                            when the underlying condition changed.  If that is not
-                            known, then using the time when the API field changed
-                            is acceptable.
-                          format: date-time
-                          type: string
-                        message:
-                          description: message is a human readable message indicating
-                            details about the transition. This may be an empty string.
-                          maxLength: 32768
-                          type: string
-                        observedGeneration:
-                          description: observedGeneration represents the .metadata.generation
-                            that the condition was set based upon. For instance, if
-                            .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
-                            is 9, the condition is out of date with respect to the
-                            current state of the instance.
-                          format: int64
-                          minimum: 0
-                          type: integer
-                        reason:
-                          description: reason contains a programmatic identifier indicating
-                            the reason for the condition's last transition. Producers
-                            of specific condition types may define expected values
-                            and meanings for this field, and whether the values are
-                            considered a guaranteed API. The value should be a CamelCase
-                            string. This field may not be empty.
-                          maxLength: 1024
-                          minLength: 1
-                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                          type: string
-                        status:
-                          description: status of the condition, one of True, False,
-                            Unknown.
-                          enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                          type: string
-                        type:
-                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            --- Many .condition.type values are consistent across
-                            resources like Available, but because arbitrary conditions
-                            can be useful (see .node.status.conditions), the ability
-                            to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                          maxLength: 316
-                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                          type: string
-                      required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                      type: object
-                    type: array
-                required:
-                - conditions
-                type: object
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               lastReconcile:
                 description: lastReconcile is the time of last reconciliation
                 format: date-time

--- a/bundle/manifests/nodeobservability.olm.openshift.io_nodeobservabilityruns.yaml
+++ b/bundle/manifests/nodeobservability.olm.openshift.io_nodeobservabilityruns.yaml
@@ -147,8 +147,6 @@ spec:
                       - type
                       type: object
                     type: array
-                required:
-                - conditions
                 type: object
               failedAgents:
                 description: FailedAgents represents the list of Nodes that could

--- a/config/crd/bases/nodeobservability.olm.openshift.io_nodeobservabilities.yaml
+++ b/config/crd/bases/nodeobservability.olm.openshift.io_nodeobservabilities.yaml
@@ -136,8 +136,6 @@ spec:
                       - type
                       type: object
                     type: array
-                required:
-                - conditions
                 type: object
               count:
                 description: Count is the number of pods (one for each node) the daemon

--- a/config/crd/bases/nodeobservability.olm.openshift.io_nodeobservabilitymachineconfigs.yaml
+++ b/config/crd/bases/nodeobservability.olm.openshift.io_nodeobservabilitymachineconfigs.yaml
@@ -54,83 +54,73 @@ spec:
               state of NodeObservabilityMachineConfig
             properties:
               conditions:
-                description: conditions represents the latest available observations
-                  of current operator state.
-                properties:
-                  conditions:
-                    items:
-                      description: "Condition contains details for one aspect of the
-                        current state of this API Resource. --- This struct is intended
-                        for direct use as an array at the field path .status.conditions.
-                        \ For example, type FooStatus struct{ // Represents the observations
-                        of a foo's current state. // Known .status.conditions.type
-                        are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type
-                        // +patchStrategy=merge // +listType=map // +listMapKey=type
-                        Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                        patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                        \n // other fields }"
-                      properties:
-                        lastTransitionTime:
-                          description: lastTransitionTime is the last time the condition
-                            transitioned from one status to another. This should be
-                            when the underlying condition changed.  If that is not
-                            known, then using the time when the API field changed
-                            is acceptable.
-                          format: date-time
-                          type: string
-                        message:
-                          description: message is a human readable message indicating
-                            details about the transition. This may be an empty string.
-                          maxLength: 32768
-                          type: string
-                        observedGeneration:
-                          description: observedGeneration represents the .metadata.generation
-                            that the condition was set based upon. For instance, if
-                            .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
-                            is 9, the condition is out of date with respect to the
-                            current state of the instance.
-                          format: int64
-                          minimum: 0
-                          type: integer
-                        reason:
-                          description: reason contains a programmatic identifier indicating
-                            the reason for the condition's last transition. Producers
-                            of specific condition types may define expected values
-                            and meanings for this field, and whether the values are
-                            considered a guaranteed API. The value should be a CamelCase
-                            string. This field may not be empty.
-                          maxLength: 1024
-                          minLength: 1
-                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                          type: string
-                        status:
-                          description: status of the condition, one of True, False,
-                            Unknown.
-                          enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                          type: string
-                        type:
-                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            --- Many .condition.type values are consistent across
-                            resources like Available, but because arbitrary conditions
-                            can be useful (see .node.status.conditions), the ability
-                            to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                          maxLength: 316
-                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                          type: string
-                      required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                      type: object
-                    type: array
-                required:
-                - conditions
-                type: object
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               lastReconcile:
                 description: lastReconcile is the time of last reconciliation
                 format: date-time

--- a/config/crd/bases/nodeobservability.olm.openshift.io_nodeobservabilityruns.yaml
+++ b/config/crd/bases/nodeobservability.olm.openshift.io_nodeobservabilityruns.yaml
@@ -148,8 +148,6 @@ spec:
                       - type
                       type: object
                     type: array
-                required:
-                - conditions
                 type: object
               failedAgents:
                 description: FailedAgents represents the list of Nodes that could


### PR DESCRIPTION
We have `conditions` twice now: 
```
status:
  conditions:
    conditions:
    - lastTransitionTime: "2022-05-31T12:18:17Z"
      message: Ready to start profiling
      reason: Ready
      status: "True"
      type: Ready
```