### PR TITLE
nodeobservability: use controlled ownerref for daemonset

### DIFF
--- a/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
@@ -33,7 +33,8 @@ metadata:
           "apiVersion": "nodeobservability.olm.openshift.io/v1alpha1",
           "kind": "NodeObservabilityRun",
           "metadata": {
-            "name": "nodeobservabilityrun-sample"
+            "name": "nodeobservabilityrun-sample",
+            "namespace": "node-observability-operator"
           },
           "spec": {
             "nodeObservabilityRef": {

--- a/config/samples/nodeobservability_v1alpha1_nodeobservabilityrun.yaml
+++ b/config/samples/nodeobservability_v1alpha1_nodeobservabilityrun.yaml
@@ -2,6 +2,7 @@ apiVersion: nodeobservability.olm.openshift.io/v1alpha1
 kind: NodeObservabilityRun
 metadata:
   name: nodeobservabilityrun-sample
+  namespace: node-observability-operator
 spec:
   nodeObservabilityRef:
     name: cluster


### PR DESCRIPTION
DaemonSet's owner reference now has the controller set to `true` which allows to trigger the reconciliation. This helps with the cases when the daemonset was removed.