### PR TITLE
Align CI Dockerfile and CPaaS Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,16 @@ COPY pkg/ pkg/
 COPY vendor/ vendor/
 COPY go.mod go.mod
 COPY go.sum go.sum
+COPY Makefile Makefile
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/node-observability-operator/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build-operator
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi8/ubi-micro:8.5
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/node-observability-operator .
 USER 65532:65532
 
 ENTRYPOINT ["/node-observability-operator"]

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -12,15 +12,16 @@ COPY pkg/ pkg/
 COPY vendor/ vendor/
 COPY go.mod go.mod
 COPY go.sum go.sum
+COPY Makefile Makefile
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/node-observability-operator/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build-operator
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.ci.openshift.org/ocp/4.10:base
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/node-observability-operator .
 USER 65532:65532
 
 ENTRYPOINT ["/node-observability-operator"]

--- a/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
@@ -347,8 +347,6 @@ spec:
                 - --zap-log-level=$(LOG_LEVEL)
                 - --operator-namespace=$(OPERATOR_NAMESPACE)
                 - --agent-image=$(RELATED_IMAGE_AGENT)
-                command:
-                - /manager
                 env:
                 - name: LOG_LEVEL
                   value: info

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,9 +27,7 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"


### PR DESCRIPTION
* Updates both Dockerfile and Dockerfile.rhel8 (CI) to use `make operator-build` instead of a direct `go build` command
* Removes the command override in `config/manager/manager.yaml` as well as the ClusterServiceVersion