### PR TITLE
Small refactoring of the machineconfig controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Note**: This Operator is in the early stages of implementation and keeps changing.
 
-The NodeObservability Operator allows you to deploy and manage [NodeObservability Agent](https://github.com/openshift/node-observability-agent) on the worker nodes. The NodeObservability agent is deployed through DaemonSets on all or selected nodes.     
+The NodeObservability Operator allows you to deploy and manage [NodeObservability Agent](https://github.com/openshift/node-observability-agent) on the worker nodes. The NodeObservability agent is deployed through DaemonSets on the selected nodes.     
 Afterward, the profiling requests can be created to trigger different types of profiling. The profiling data will be accessible in the root filesystem of the NodeObservability Agent.
 
 - [Deploying the  NodeObservability Operator](#deploying-the-nodeobservability-operator)

--- a/cmd/node-observability-operator/main.go
+++ b/cmd/node-observability-operator/main.go
@@ -55,9 +55,8 @@ const (
 )
 
 var (
-	scheme               = runtime.NewScheme()
-	setupLog             = ctrl.Log.WithName("node-observability")
-	nodeObsMCOReconciler *machineconfigcontroller.MachineConfigReconciler
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("node-observability")
 )
 
 func init() {
@@ -113,7 +112,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "94c735b6.olm.openshift.io",
-		Namespace:              "node-observability-operator",
+		Namespace:              operatorNamespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -132,7 +131,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&nodeobservabilitycontroller.NodeObservabilityReconciler{
+	if err := (&nodeobservabilitycontroller.NodeObservabilityReconciler{
 		Client:            mgr.GetClient(),
 		ClusterWideClient: clusterWideCli,
 		Scheme:            mgr.GetScheme(),
@@ -144,16 +143,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if nodeObsMCOReconciler, err = machineconfigcontroller.New(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "NodeObservabilityMachineConfig")
-		os.Exit(1)
-	}
-	if err = nodeObsMCOReconciler.SetupWithManager(mgr); err != nil {
+	if err := machineconfigcontroller.New(mgr).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NodeObservabilityMachineConfig")
 		os.Exit(1)
 	}
 
-	if err = (&nodeobservabilityrun.NodeObservabilityRunReconciler{
+	if err := (&nodeobservabilityrun.NodeObservabilityRunReconciler{
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		Log:       ctrl.Log.WithName("controller").WithName("NodeObservabilityRun"),

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,7 +106,7 @@ metadata:
   name: cluster
 spec:
   nodeSelector:
-    "node-role.kubernetes.io/worker": ""
+    app: example
   type: crio-kubelet
 ```
 

--- a/pkg/operator/controller/machineconfig/controller.go
+++ b/pkg/operator/controller/machineconfig/controller.go
@@ -57,9 +57,8 @@ type MachineConfigReconciler struct {
 	Scheme        *runtime.Scheme
 	EventRecorder record.EventRecorder
 
-	Node          NodeSyncData
-	MachineConfig MachineConfigSyncData
-	CtrlConfig    *v1alpha1.NodeObservabilityMachineConfig
+	Node       NodeSyncData
+	CtrlConfig *v1alpha1.NodeObservabilityMachineConfig
 }
 
 // New returns a new MachineConfigReconciler instance.
@@ -73,9 +72,6 @@ func New(mgr ctrl.Manager) *MachineConfigReconciler {
 
 		Node: NodeSyncData{
 			PrevReconcileUpd: make(map[string]LabelInfo),
-		},
-		MachineConfig: MachineConfigSyncData{
-			PrevReconcileUpd: make(map[string]MachineConfigInfo),
 		},
 	}
 }
@@ -425,13 +421,11 @@ func (r *MachineConfigReconciler) ensureProfConfDisabled(ctx context.Context) (b
 func (r *MachineConfigReconciler) ensureReqMCExists(ctx context.Context) (int, error) {
 	updatedCount := 0
 	if r.CtrlConfig.Spec.Debug.EnableCrioProfiling {
-		updated, err := r.enableCrioProf(ctx)
+		err := r.enableCrioProf(ctx)
 		if err != nil {
 			return updatedCount, err
 		}
-		if updated {
-			updatedCount++
-		}
+		updatedCount++
 	}
 	return updatedCount, nil
 }

--- a/pkg/operator/controller/machineconfig/controller_test.go
+++ b/pkg/operator/controller/machineconfig/controller_test.go
@@ -135,7 +135,7 @@ func testNodeObsNodes() []runtime.Object {
 }
 
 func testNodeObsMCP(r *MachineConfigReconciler) *mcv1.MachineConfigPool {
-	mcp := r.GetProfilingMCP(ProfilingMCPName)
+	mcp := r.getCrioProfMachineConfigPool(ProfilingMCPName)
 
 	mcp.Spec.Configuration.ObjectReference = corev1.ObjectReference{
 		Name: "rendered-nodeobservability-9d2d6f47a54e5828cf2917d760b54a99",

--- a/pkg/operator/controller/machineconfig/controller_test.go
+++ b/pkg/operator/controller/machineconfig/controller_test.go
@@ -896,6 +896,23 @@ func TestReconcileClientFakes(t *testing.T) {
 			arg1: ctx,
 			arg2: request,
 			preReq: func(r *MachineConfigReconciler, m *machineconfigfakes.FakeImpl) {
+				m.ClientListCalls(func(
+					ctx context.Context,
+					list client.ObjectList,
+					opts ...client.ListOption) error {
+					switch o := list.(type) {
+					case *corev1.NodeList:
+						n := &corev1.NodeList{}
+						nodes := testWorkerNodes()
+						for i := range nodes {
+							node := nodes[i].(*corev1.Node)
+							node.ObjectMeta.Labels[NodeObservabilityNodeRoleLabelName] = Empty
+							n.Items = append(n.Items, *node)
+						}
+						n.DeepCopyInto(o)
+					}
+					return nil
+				})
 				m.ClientGetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
 					switch o := obj.(type) {
 					case *mcv1.MachineConfigPool:
@@ -1016,6 +1033,23 @@ func TestReconcileClientFakes(t *testing.T) {
 			arg1: ctx,
 			arg2: request,
 			preReq: func(r *MachineConfigReconciler, m *machineconfigfakes.FakeImpl) {
+				m.ClientListCalls(func(
+					ctx context.Context,
+					list client.ObjectList,
+					opts ...client.ListOption) error {
+					switch o := list.(type) {
+					case *corev1.NodeList:
+						n := &corev1.NodeList{}
+						nodes := testWorkerNodes()
+						for i := range nodes {
+							node := nodes[i].(*corev1.Node)
+							node.ObjectMeta.Labels[NodeObservabilityNodeRoleLabelName] = Empty
+							n.Items = append(n.Items, *node)
+						}
+						n.DeepCopyInto(o)
+					}
+					return nil
+				})
 				m.ClientGetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
 					switch o := obj.(type) {
 					case *mcv1.MachineConfigPool:
@@ -1054,6 +1088,23 @@ func TestReconcileClientFakes(t *testing.T) {
 			arg1: ctx,
 			arg2: request,
 			preReq: func(r *MachineConfigReconciler, m *machineconfigfakes.FakeImpl) {
+				m.ClientListCalls(func(
+					ctx context.Context,
+					list client.ObjectList,
+					opts ...client.ListOption) error {
+					switch o := list.(type) {
+					case *corev1.NodeList:
+						n := &corev1.NodeList{}
+						nodes := testWorkerNodes()
+						for i := range nodes {
+							node := nodes[i].(*corev1.Node)
+							node.ObjectMeta.Labels[NodeObservabilityNodeRoleLabelName] = Empty
+							n.Items = append(n.Items, *node)
+						}
+						n.DeepCopyInto(o)
+					}
+					return nil
+				})
 				m.ClientGetCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) error {
 					switch o := obj.(type) {
 					case *mcv1.MachineConfigPool:
@@ -1649,33 +1700,26 @@ func TestEnsureProfConfEnabled(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "revertNodeLabeling failure",
-			preReq: func(r *MachineConfigReconciler, m *machineconfigfakes.FakeImpl) {
-				m.ClientGetCalls(func(
-					ctx context.Context,
-					ns types.NamespacedName,
-					obj client.Object) error {
-					switch o := obj.(type) {
-					case *corev1.Node:
-						nodes := testNodeObsNodes()
-						for _, node := range nodes {
-							if ns.Name == node.(*corev1.Node).GetName() {
-								node.(*corev1.Node).DeepCopyInto(o)
-							}
-						}
-					}
-					return nil
-				})
-				m.ClientListReturns(testError)
-				m.ClientPatchReturns(testError)
-			},
-			requeue: true,
-			wantErr: true,
-		},
-		{
 			name: "ensureReqMCPExists failure",
 			preReq: func(r *MachineConfigReconciler, m *machineconfigfakes.FakeImpl) {
 				r.CtrlConfig.SetNamespace("test")
+				m.ClientListCalls(func(
+					ctx context.Context,
+					list client.ObjectList,
+					opts ...client.ListOption) error {
+					switch o := list.(type) {
+					case *corev1.NodeList:
+						n := &corev1.NodeList{}
+						nodes := testWorkerNodes()
+						for i := range nodes {
+							node := nodes[i].(*corev1.Node)
+							node.ObjectMeta.Labels[NodeObservabilityNodeRoleLabelName] = Empty
+							n.Items = append(n.Items, *node)
+						}
+						n.DeepCopyInto(o)
+					}
+					return nil
+				})
 			},
 			requeue: false,
 			wantErr: true,
@@ -1684,6 +1728,23 @@ func TestEnsureProfConfEnabled(t *testing.T) {
 			name: "ensureReqMCExists failure",
 			preReq: func(r *MachineConfigReconciler, m *machineconfigfakes.FakeImpl) {
 				r.CtrlConfig.SetNamespace("test")
+				m.ClientListCalls(func(
+					ctx context.Context,
+					list client.ObjectList,
+					opts ...client.ListOption) error {
+					switch o := list.(type) {
+					case *corev1.NodeList:
+						n := &corev1.NodeList{}
+						nodes := testWorkerNodes()
+						for i := range nodes {
+							node := nodes[i].(*corev1.Node)
+							node.ObjectMeta.Labels[NodeObservabilityNodeRoleLabelName] = Empty
+							n.Items = append(n.Items, *node)
+						}
+						n.DeepCopyInto(o)
+					}
+					return nil
+				})
 			},
 			requeue: false,
 			wantErr: true,

--- a/pkg/operator/controller/machineconfig/controller_test.go
+++ b/pkg/operator/controller/machineconfig/controller_test.go
@@ -59,9 +59,6 @@ func testReconciler() *MachineConfigReconciler {
 		Node: NodeSyncData{
 			PrevReconcileUpd: make(map[string]LabelInfo),
 		},
-		MachineConfig: MachineConfigSyncData{
-			PrevReconcileUpd: make(map[string]MachineConfigInfo),
-		},
 	}
 }
 
@@ -294,7 +291,7 @@ func TestReconcile(t *testing.T) {
 	labeledNodes := testNodeObsNodes()
 	mcp := testNodeObsMCP(r)
 	workerMCP := testWorkerMCP()
-	criomc, _ := r.getCrioConfig()
+	criomc, _ := r.getCrioProfMachineConfig()
 
 	tests := []struct {
 		name       string
@@ -844,7 +841,7 @@ func TestReconcileClientFakes(t *testing.T) {
 						}
 						mcp.DeepCopyInto(o)
 					case *mcv1.MachineConfig:
-						mc, _ := r.getCrioConfig()
+						mc, _ := r.getCrioProfMachineConfig()
 						mc.DeepCopyInto(o)
 					case *v1alpha1.NodeObservabilityMachineConfig:
 						nomc := testNodeObsMC()
@@ -888,7 +885,7 @@ func TestReconcileClientFakes(t *testing.T) {
 						}
 						mcp.DeepCopyInto(o)
 					case *mcv1.MachineConfig:
-						mc, _ := r.getCrioConfig()
+						mc, _ := r.getCrioProfMachineConfig()
 						mc.DeepCopyInto(o)
 					case *v1alpha1.NodeObservabilityMachineConfig:
 						nomc := testNodeObsMC()
@@ -926,7 +923,7 @@ func TestReconcileClientFakes(t *testing.T) {
 						}
 						mcp.DeepCopyInto(o)
 					case *mcv1.MachineConfig:
-						mc, _ := r.getCrioConfig()
+						mc, _ := r.getCrioProfMachineConfig()
 						mc.DeepCopyInto(o)
 					case *v1alpha1.NodeObservabilityMachineConfig:
 						nomc := testNodeObsMC()
@@ -977,7 +974,7 @@ func TestReconcileClientFakes(t *testing.T) {
 						}
 						mcp.DeepCopyInto(o)
 					case *mcv1.MachineConfig:
-						mc, _ := r.getCrioConfig()
+						mc, _ := r.getCrioProfMachineConfig()
 						mc.DeepCopyInto(o)
 					case *v1alpha1.NodeObservabilityMachineConfig:
 						nomc := testNodeObsMC()
@@ -1049,7 +1046,7 @@ func TestReconcileClientFakes(t *testing.T) {
 					case *mcv1.MachineConfigPool:
 						return testError
 					case *mcv1.MachineConfig:
-						mc, _ := r.getCrioConfig()
+						mc, _ := r.getCrioProfMachineConfig()
 						mc.DeepCopyInto(o)
 					case *v1alpha1.NodeObservabilityMachineConfig:
 						nomc := testNodeObsMC()
@@ -1157,7 +1154,7 @@ func TestReconcileClientFakes(t *testing.T) {
 						}
 						mcp.DeepCopyInto(o)
 					case *mcv1.MachineConfig:
-						mc, _ := r.getCrioConfig()
+						mc, _ := r.getCrioProfMachineConfig()
 						mc.DeepCopyInto(o)
 					case *v1alpha1.NodeObservabilityMachineConfig:
 						nomc := testNodeObsMC()
@@ -1236,7 +1233,7 @@ func TestReconcileClientFakes(t *testing.T) {
 							mcv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
 						mcp.DeepCopyInto(o)
 					case *mcv1.MachineConfig:
-						mc, _ := r.getCrioConfig()
+						mc, _ := r.getCrioProfMachineConfig()
 						mc.DeepCopyInto(o)
 					case *v1alpha1.NodeObservabilityMachineConfig:
 						nomc := testNodeObsMC()
@@ -1308,7 +1305,7 @@ func TestReconcileClientFakes(t *testing.T) {
 							mcv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
 						mcp.DeepCopyInto(o)
 					case *mcv1.MachineConfig:
-						mc, _ := r.getCrioConfig()
+						mc, _ := r.getCrioProfMachineConfig()
 						mc.DeepCopyInto(o)
 					case *v1alpha1.NodeObservabilityMachineConfig:
 						nomc := testNodeObsMC()

--- a/pkg/operator/controller/machineconfig/crio.go
+++ b/pkg/operator/controller/machineconfig/crio.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,78 +32,9 @@ import (
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
-// enableCrioProf checks if CRI-O MachineConfig CR for
-// enabling profiling exists, if not creates the resource
-func (r *MachineConfigReconciler) enableCrioProf(ctx context.Context) (bool, error) {
-	createdNow := false
-	namespace := types.NamespacedName{Name: CrioProfilingConfigName}
-
-	err := r.createCrioProfConf(ctx)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return createdNow, err
-	}
-	if err == nil {
-		createdNow = true
-	}
-
-	// grace time for client cache to get refreshed
-	time.Sleep(500 * time.Millisecond)
-
-	criomc, err := r.fetchCrioProfConf(ctx, namespace)
-	if err != nil {
-		return createdNow, fmt.Errorf("failed to ensure crio profiling config was indeed created: %w", err)
-	}
-
-	r.Lock()
-	defer r.Unlock()
-	r.MachineConfig.PrevReconcileUpd["crio"] = MachineConfigInfo{
-		op:     "create",
-		config: criomc,
-	}
-
-	return createdNow, nil
-}
-
-// disableCrioProf checks if CRI-O MachineConfig CR for
-// enabling profiling exists, if exists delete the resource
-func (r *MachineConfigReconciler) disableCrioProf(ctx context.Context) error {
-	namespace := types.NamespacedName{Name: CrioProfilingConfigName}
-
-	criomc, err := r.fetchCrioProfConf(ctx, namespace)
-	if errors.IsNotFound(err) {
-		return nil
-	}
-
-	if err != nil {
-		return err
-	}
-
-	if err := r.deleteCrioProfConf(ctx, criomc); err != nil {
-		return err
-	}
-
-	r.Lock()
-	defer r.Unlock()
-	r.MachineConfig.PrevReconcileUpd["crio"] = MachineConfigInfo{
-		op: "delete",
-	}
-
-	return nil
-}
-
-// fetchCrioProfConf is for fetching the CRI-O MC CR created
-// by this controller for enabling profiling
-func (r *MachineConfigReconciler) fetchCrioProfConf(ctx context.Context, namespace types.NamespacedName) (*mcv1.MachineConfig, error) {
-	criomc := &mcv1.MachineConfig{}
-	if err := r.ClientGet(ctx, namespace, criomc); err != nil {
-		return nil, err
-	}
-	return criomc, nil
-}
-
-// createCrioProfConf is for creating CRI-O MC CR
-func (r *MachineConfigReconciler) createCrioProfConf(ctx context.Context) error {
-	criomc, err := r.getCrioConfig()
+// enableCrioProf checks if MachineConfig CR for CRI-O profiling exists, if not creates one.
+func (r *MachineConfigReconciler) enableCrioProf(ctx context.Context) error {
+	criomc, err := r.getCrioProfMachineConfig()
 	if err != nil {
 		return err
 	}
@@ -113,27 +43,60 @@ func (r *MachineConfigReconciler) createCrioProfConf(ctx context.Context) error 
 		return fmt.Errorf("failed to update owner info in CRI-O profiling MC resource: %w", err)
 	}
 
-	if err := r.ClientCreate(ctx, criomc); err != nil {
+	if err := r.ClientCreate(ctx, criomc); err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create crio profiling config %s: %w", criomc.Name, err)
 	}
 
-	r.Log.V(1).Info("Successfully created CRI-O MC for enabling profiling", "CrioProfilingConfigName", CrioProfilingConfigName)
+	r.Log.V(1).Info("Successfully created MachineConfig to enable CRI-O profiling", "CrioProfilingConfigName", CrioProfilingConfigName)
 	return nil
 }
 
-// deleteCrioProfConf is for deleting CRI-O MC CR
-func (r *MachineConfigReconciler) deleteCrioProfConf(ctx context.Context, criomc *mcv1.MachineConfig) error {
-	if err := r.ClientDelete(ctx, criomc); err != nil {
-		return fmt.Errorf("failed to remove crio profiling config %s: %w", criomc.Name, err)
+// disableCrioProf checks if CRI-O MachineConfig CR for
+// enabling profiling exists, if exists delete the resource
+func (r *MachineConfigReconciler) disableCrioProf(ctx context.Context) error {
+	criomc := &mcv1.MachineConfig{}
+	if err := r.ClientGet(ctx, types.NamespacedName{Name: CrioProfilingConfigName}, criomc); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	}
 
-	r.Log.V(1).Info("Successfully removed CRI-O MC to disable profiling", "CrioProfilingConfigName", CrioProfilingConfigName)
+	if err := r.ClientDelete(ctx, criomc); err != nil {
+		return err
+	}
+
+	r.Log.V(1).Info("Successfully removed MachineConfig to disable CRI-O profiling", "CrioProfilingConfigName", CrioProfilingConfigName)
+
 	return nil
 }
 
-// getCrioIgnitionConfig returns the required ignition config
-// required for creating CRI-O MC CR
-func getCrioIgnitionConfig() igntypes.Config {
+// getCrioProfMachineConfig returns the MachineConfig CR definition to enable CRI-O profiling.
+func (r *MachineConfigReconciler) getCrioProfMachineConfig() (*mcv1.MachineConfig, error) {
+	config := getCrioProfIgnitionConfig()
+
+	rawExt, err := convertIgnConfToRawExt(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       MCKind,
+			APIVersion: MCAPIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   CrioProfilingConfigName,
+			Labels: MachineConfigLabels,
+		},
+		Spec: mcv1.MachineConfigSpec{
+			Config: rawExt,
+		},
+	}, nil
+}
+
+// getCrioProfIgnitionConfig returns the ignition config to enable CRI-O profiling.
+func getCrioProfIgnitionConfig() igntypes.Config {
 	dropins := []igntypes.Dropin{
 		{
 			Name:     CrioUnixSocketConfFile,
@@ -159,7 +122,7 @@ func getCrioIgnitionConfig() igntypes.Config {
 }
 
 // convertIgnConfToRawExt converts the CRI-O ignition configuration
-// to k8s raw extension form
+// to k8s raw extension form.
 func convertIgnConfToRawExt(config igntypes.Config) (k8sruntime.RawExtension, error) {
 	data, err := json.Marshal(config)
 	if err != nil {
@@ -168,29 +131,5 @@ func convertIgnConfToRawExt(config igntypes.Config) (k8sruntime.RawExtension, er
 
 	return k8sruntime.RawExtension{
 		Raw: data,
-	}, nil
-}
-
-// getCrioConfig returns the CRI-O MC CR data required for creating it
-func (r *MachineConfigReconciler) getCrioConfig() (*mcv1.MachineConfig, error) {
-	config := getCrioIgnitionConfig()
-
-	rawExt, err := convertIgnConfToRawExt(config)
-	if err != nil {
-		return nil, err
-	}
-
-	return &mcv1.MachineConfig{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       MCKind,
-			APIVersion: MCAPIVersion,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   CrioProfilingConfigName,
-			Labels: MachineConfigLabels,
-		},
-		Spec: mcv1.MachineConfigSpec{
-			Config: rawExt,
-		},
 	}, nil
 }

--- a/pkg/operator/controller/machineconfig/impl.go
+++ b/pkg/operator/controller/machineconfig/impl.go
@@ -19,8 +19,6 @@ package machineconfigcontroller
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -32,8 +30,6 @@ type defaultImpl struct {
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . impl
 type impl interface {
-	ManagerGetScheme(manager.Manager) *runtime.Scheme
-	ManagerGetEventRecorderFor(manager.Manager, string) record.EventRecorder
 	ClientGet(context.Context, client.ObjectKey, client.Object) error
 	ClientList(context.Context, client.ObjectList, ...client.ListOption) error
 	ClientStatusUpdate(context.Context, client.Object, ...client.UpdateOption) error
@@ -43,23 +39,10 @@ type impl interface {
 	ClientPatch(context.Context, client.Object, client.Patch, ...client.PatchOption) error
 }
 
-func NewClient(m manager.Manager, impls ...impl) impl {
-	if len(impls) != 0 {
-		return impls[0]
-	}
+func NewClient(m manager.Manager) impl {
 	return &defaultImpl{
 		Client: m.GetClient(),
 	}
-}
-
-func (c *defaultImpl) ManagerGetScheme(m manager.Manager) *runtime.Scheme {
-	return m.GetScheme()
-}
-
-func (c *defaultImpl) ManagerGetEventRecorderFor(
-	m manager.Manager, name string,
-) record.EventRecorder {
-	return m.GetEventRecorderFor(name)
 }
 
 func (c *defaultImpl) ClientGet(

--- a/pkg/operator/controller/machineconfig/machineconfigfakes/fake_impl.go
+++ b/pkg/operator/controller/machineconfig/machineconfigfakes/fake_impl.go
@@ -5,11 +5,8 @@ import (
 	"context"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 type FakeImpl struct {
@@ -104,29 +101,6 @@ type FakeImpl struct {
 	}
 	clientUpdateReturnsOnCall map[int]struct {
 		result1 error
-	}
-	ManagerGetEventRecorderForStub        func(manager.Manager, string) record.EventRecorder
-	managerGetEventRecorderForMutex       sync.RWMutex
-	managerGetEventRecorderForArgsForCall []struct {
-		arg1 manager.Manager
-		arg2 string
-	}
-	managerGetEventRecorderForReturns struct {
-		result1 record.EventRecorder
-	}
-	managerGetEventRecorderForReturnsOnCall map[int]struct {
-		result1 record.EventRecorder
-	}
-	ManagerGetSchemeStub        func(manager.Manager) *runtime.Scheme
-	managerGetSchemeMutex       sync.RWMutex
-	managerGetSchemeArgsForCall []struct {
-		arg1 manager.Manager
-	}
-	managerGetSchemeReturns struct {
-		result1 *runtime.Scheme
-	}
-	managerGetSchemeReturnsOnCall map[int]struct {
-		result1 *runtime.Scheme
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -574,129 +548,6 @@ func (fake *FakeImpl) ClientUpdateReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) ManagerGetEventRecorderFor(arg1 manager.Manager, arg2 string) record.EventRecorder {
-	fake.managerGetEventRecorderForMutex.Lock()
-	ret, specificReturn := fake.managerGetEventRecorderForReturnsOnCall[len(fake.managerGetEventRecorderForArgsForCall)]
-	fake.managerGetEventRecorderForArgsForCall = append(fake.managerGetEventRecorderForArgsForCall, struct {
-		arg1 manager.Manager
-		arg2 string
-	}{arg1, arg2})
-	stub := fake.ManagerGetEventRecorderForStub
-	fakeReturns := fake.managerGetEventRecorderForReturns
-	fake.recordInvocation("ManagerGetEventRecorderFor", []interface{}{arg1, arg2})
-	fake.managerGetEventRecorderForMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeImpl) ManagerGetEventRecorderForCallCount() int {
-	fake.managerGetEventRecorderForMutex.RLock()
-	defer fake.managerGetEventRecorderForMutex.RUnlock()
-	return len(fake.managerGetEventRecorderForArgsForCall)
-}
-
-func (fake *FakeImpl) ManagerGetEventRecorderForCalls(stub func(manager.Manager, string) record.EventRecorder) {
-	fake.managerGetEventRecorderForMutex.Lock()
-	defer fake.managerGetEventRecorderForMutex.Unlock()
-	fake.ManagerGetEventRecorderForStub = stub
-}
-
-func (fake *FakeImpl) ManagerGetEventRecorderForArgsForCall(i int) (manager.Manager, string) {
-	fake.managerGetEventRecorderForMutex.RLock()
-	defer fake.managerGetEventRecorderForMutex.RUnlock()
-	argsForCall := fake.managerGetEventRecorderForArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeImpl) ManagerGetEventRecorderForReturns(result1 record.EventRecorder) {
-	fake.managerGetEventRecorderForMutex.Lock()
-	defer fake.managerGetEventRecorderForMutex.Unlock()
-	fake.ManagerGetEventRecorderForStub = nil
-	fake.managerGetEventRecorderForReturns = struct {
-		result1 record.EventRecorder
-	}{result1}
-}
-
-func (fake *FakeImpl) ManagerGetEventRecorderForReturnsOnCall(i int, result1 record.EventRecorder) {
-	fake.managerGetEventRecorderForMutex.Lock()
-	defer fake.managerGetEventRecorderForMutex.Unlock()
-	fake.ManagerGetEventRecorderForStub = nil
-	if fake.managerGetEventRecorderForReturnsOnCall == nil {
-		fake.managerGetEventRecorderForReturnsOnCall = make(map[int]struct {
-			result1 record.EventRecorder
-		})
-	}
-	fake.managerGetEventRecorderForReturnsOnCall[i] = struct {
-		result1 record.EventRecorder
-	}{result1}
-}
-
-func (fake *FakeImpl) ManagerGetScheme(arg1 manager.Manager) *runtime.Scheme {
-	fake.managerGetSchemeMutex.Lock()
-	ret, specificReturn := fake.managerGetSchemeReturnsOnCall[len(fake.managerGetSchemeArgsForCall)]
-	fake.managerGetSchemeArgsForCall = append(fake.managerGetSchemeArgsForCall, struct {
-		arg1 manager.Manager
-	}{arg1})
-	stub := fake.ManagerGetSchemeStub
-	fakeReturns := fake.managerGetSchemeReturns
-	fake.recordInvocation("ManagerGetScheme", []interface{}{arg1})
-	fake.managerGetSchemeMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeImpl) ManagerGetSchemeCallCount() int {
-	fake.managerGetSchemeMutex.RLock()
-	defer fake.managerGetSchemeMutex.RUnlock()
-	return len(fake.managerGetSchemeArgsForCall)
-}
-
-func (fake *FakeImpl) ManagerGetSchemeCalls(stub func(manager.Manager) *runtime.Scheme) {
-	fake.managerGetSchemeMutex.Lock()
-	defer fake.managerGetSchemeMutex.Unlock()
-	fake.ManagerGetSchemeStub = stub
-}
-
-func (fake *FakeImpl) ManagerGetSchemeArgsForCall(i int) manager.Manager {
-	fake.managerGetSchemeMutex.RLock()
-	defer fake.managerGetSchemeMutex.RUnlock()
-	argsForCall := fake.managerGetSchemeArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeImpl) ManagerGetSchemeReturns(result1 *runtime.Scheme) {
-	fake.managerGetSchemeMutex.Lock()
-	defer fake.managerGetSchemeMutex.Unlock()
-	fake.ManagerGetSchemeStub = nil
-	fake.managerGetSchemeReturns = struct {
-		result1 *runtime.Scheme
-	}{result1}
-}
-
-func (fake *FakeImpl) ManagerGetSchemeReturnsOnCall(i int, result1 *runtime.Scheme) {
-	fake.managerGetSchemeMutex.Lock()
-	defer fake.managerGetSchemeMutex.Unlock()
-	fake.ManagerGetSchemeStub = nil
-	if fake.managerGetSchemeReturnsOnCall == nil {
-		fake.managerGetSchemeReturnsOnCall = make(map[int]struct {
-			result1 *runtime.Scheme
-		})
-	}
-	fake.managerGetSchemeReturnsOnCall[i] = struct {
-		result1 *runtime.Scheme
-	}{result1}
-}
-
 func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -714,10 +565,6 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.clientStatusUpdateMutex.RUnlock()
 	fake.clientUpdateMutex.RLock()
 	defer fake.clientUpdateMutex.RUnlock()
-	fake.managerGetEventRecorderForMutex.RLock()
-	defer fake.managerGetEventRecorderForMutex.RUnlock()
-	fake.managerGetSchemeMutex.RLock()
-	defer fake.managerGetSchemeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/operator/controller/machineconfig/mcp.go
+++ b/pkg/operator/controller/machineconfig/mcp.go
@@ -184,10 +184,10 @@ func (r *MachineConfigReconciler) checkWorkerMCPStatus(ctx context.Context) (ctr
 
 	if mcv1.IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcv1.MachineConfigPoolUpdated) {
 
-		if err := r.ensureReqMCNotExists(ctx); err != nil {
+		if err := r.disableCrioProf(ctx); err != nil {
 			return ctrl.Result{RequeueAfter: defaultRequeueTime}, err
 		}
-		if err := r.ensureReqMCPNotExists(ctx); err != nil {
+		if err := r.deleteProfMCP(ctx); err != nil {
 			return ctrl.Result{RequeueAfter: defaultRequeueTime}, err
 		}
 

--- a/pkg/operator/controller/machineconfig/nodes.go
+++ b/pkg/operator/controller/machineconfig/nodes.go
@@ -89,7 +89,7 @@ func (r *MachineConfigReconciler) ensureReqNodeLabelNotExists(ctx context.Contex
 		updNodeCount++
 	}
 
-	if updNodeCount > 0 {
+	if updNodeCount == len(nodeList.Items) {
 		r.Log.V(1).Info("Successfully removed nodeobservability role from nodes with worker role", "NodeCount", updNodeCount)
 	}
 	return updNodeCount, nil

--- a/pkg/operator/controller/machineconfig/nodes.go
+++ b/pkg/operator/controller/machineconfig/nodes.go
@@ -166,7 +166,8 @@ func (r *MachineConfigReconciler) revertNodeLabeling(ctx context.Context) error 
 	return nil
 }
 
-// ensureReqNodeLabelNotExists is for checking and removing the labels added to nodes
+// ensureReqNodeLabelNotExists removes the nodeobservability label from the nodes.
+// Returns the number of updated nodes.
 func (r *MachineConfigReconciler) ensureReqNodeLabelNotExists(ctx context.Context) (int, error) {
 	r.Lock()
 	defer r.Unlock()

--- a/pkg/operator/controller/machineconfig/types.go
+++ b/pkg/operator/controller/machineconfig/types.go
@@ -38,19 +38,5 @@ type ResourcePatchValue struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
-// MachineConfigSyncData is for storing the state
-// of the MC created for enabling profiling of
-// requested services
-type MachineConfigSyncData struct {
-	PrevReconcileUpd map[string]MachineConfigInfo
-}
-
-// MachineConfigInfo is for storing the state
-// data of MC operations
-type MachineConfigInfo struct {
-	op     string
-	config interface{}
-}
-
 // patchOp is defined for patch operation type
 type patchOp int

--- a/pkg/operator/controller/machineconfig/types.go
+++ b/pkg/operator/controller/machineconfig/types.go
@@ -16,31 +16,6 @@ limitations under the License.
 
 package machineconfigcontroller
 
-import (
-	"sync"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
-
-	"github.com/go-logr/logr"
-
-	"github.com/openshift/node-observability-operator/api/v1alpha1"
-)
-
-// MachineConfigReconciler reconciles a NodeObservabilityMachineConfig object
-type MachineConfigReconciler struct {
-	impl
-	sync.RWMutex
-
-	Log           logr.Logger
-	Scheme        *runtime.Scheme
-	EventRecorder record.EventRecorder
-
-	Node          NodeSyncData
-	MachineConfig MachineConfigSyncData
-	CtrlConfig    *v1alpha1.NodeObservabilityMachineConfig
-}
-
 // NodeSyncData is for storing the state
 // of node operations made for enabling profiling
 type NodeSyncData struct {

--- a/pkg/operator/controller/machineconfig/types.go
+++ b/pkg/operator/controller/machineconfig/types.go
@@ -16,20 +16,6 @@ limitations under the License.
 
 package machineconfigcontroller
 
-// NodeSyncData is for storing the state
-// of node operations made for enabling profiling
-type NodeSyncData struct {
-	PrevReconcileUpd map[string]LabelInfo
-}
-
-// LabelInfo is storing for the label changes
-// made to the nodes
-type LabelInfo struct {
-	key   string
-	value string
-	op    patchOp
-}
-
 // ResourcePatchValue is for creating the patch
 // request for updating a resource
 type ResourcePatchValue struct {


### PR DESCRIPTION
The main idea was to simplify (less code) and clarify (more meaningful method names and comments).

Main things done in this PR:
- No more node label reverting/re-adding in case the adding or the removal fails. This just doesn't make sense, if we fail to add or remove label - we report an error and reconcile again after.
- With the node label reverting gone, the need for the internal node and machineconfig maps which keep the collection of the synced data is gone too.
- The before mentioned maps used a mutex. That was quite weird, because: 1) there is no concurrent read/writes of these maps, 2) the same mutex was used for both maps (and for the status updated too!), 3) it was not properly used - not all read/writes were protected by a mutex locking.
- `ensureProfConfEnabled` was simplified - 1) modification counter was removed, 2) no MC or MCP is created if no nodes were labled (unit test modifications is due to this)
- A lot of functions were removed just because they didn't have much logic and were just adding complexity