### PR TITLE
CFE-510: Enforce the desired state of the operand objects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM docker.io/golang:1.17 as builder
 # TODO: Switch to UBI golang image when 1.17 is released
 # FROM registry.access.redhat.com/ubi8/go-toolset:latest
 

--- a/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
@@ -443,6 +443,8 @@ spec:
           - create
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - ""
@@ -474,6 +476,8 @@ spec:
           - delete
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - ""
@@ -484,6 +488,8 @@ spec:
           - delete
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - rbac.authorization.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -221,6 +221,8 @@ rules:
   - create
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -252,6 +254,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -262,6 +266,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coreos/ignition/v2 v2.13.0
 	github.com/go-logr/logr v1.2.2
 	github.com/golangci/golangci-lint v1.42.1
-	github.com/google/go-cmp v0.5.7
+	github.com/google/go-cmp v0.5.8
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0
 	github.com/onsi/ginkgo/v2 v2.0.0
 	github.com/onsi/gomega v1.18.1
@@ -17,6 +17,7 @@ require (
 	k8s.io/api v0.23.4
 	k8s.io/apimachinery v0.23.4
 	k8s.io/client-go v0.23.4
+	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 	sigs.k8s.io/controller-runtime v0.11.1
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220423154536-b1e1a4f79554
 	sigs.k8s.io/controller-tools v0.8.0
@@ -208,7 +209,6 @@ require (
 	k8s.io/component-base v0.23.1 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
-	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
 	mvdan.cc/gofumpt v0.1.1 // indirect
 	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed // indirect
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect

--- a/go.sum
+++ b/go.sum
@@ -672,8 +672,8 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
-github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-intervals v0.0.2/go.mod h1:MkaR3LNRfeKLPmqgJYs4E66z5InYjmCjbbr4TQlcT6Y=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pkg/operator/controller/machineconfig/controller.go
+++ b/pkg/operator/controller/machineconfig/controller.go
@@ -28,12 +28,13 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
+
+	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/go-logr/logr"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	"github.com/openshift/node-observability-operator/api/v1alpha1"
@@ -62,7 +63,7 @@ type MachineConfigReconciler struct {
 func New(mgr ctrl.Manager) *MachineConfigReconciler {
 	return &MachineConfigReconciler{
 		impl:          NewClient(mgr),
-		Log:           ctrl.Log.WithName("controller").WithName("NodeObservabilityMachineConfig"),
+		Log:           ctrl.Log.WithName("controller.nodeobservabilitymachineconfig"),
 		Scheme:        mgr.GetScheme(),
 		EventRecorder: mgr.GetEventRecorderFor("node-observability-operator"),
 	}
@@ -80,12 +81,10 @@ func New(mgr ctrl.Manager) *MachineConfigReconciler {
 // MachineConfigs, controller creates the required MachineConfigs, MachineConfigPool
 // and labels the nodes where the changes are to be applied.
 func (r *MachineConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
-
 	if ctxLog, err := logr.FromContext(ctx); err == nil {
 		r.Log = ctxLog
 	}
-
-	r.Log.V(1).Info("Reconciling NodeObservabilityMachineConfig")
+	r.Log.V(1).Info("reconciling", "request", req)
 
 	// Fetch the NodeObservabilityMachineConfig CR
 	r.CtrlConfig = &v1alpha1.NodeObservabilityMachineConfig{}
@@ -94,16 +93,15 @@ func (r *MachineConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
-			r.Log.V(1).Info("NodeObservabilityMachineConfig resource not found. Ignoring as it could have been deleted")
+			r.Log.V(1).Info("nodeobservabilitymachineconfig resource not found. Ignoring as it could have been deleted")
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return ctrl.Result{RequeueAfter: defaultRequeueTime}, fmt.Errorf("failed to fetch NodeObservabilityMachineConfig: %w", err)
+		return ctrl.Result{RequeueAfter: defaultRequeueTime}, fmt.Errorf("failed to fetch nodeobservabilitymachineconfig: %w", err)
 	}
-	r.Log.V(1).Info("NodeObservabilityMachineConfig resource found")
 
 	if !r.CtrlConfig.DeletionTimestamp.IsZero() {
-		r.Log.V(1).Info("NodeObservabilityMachineConfig resource marked for deletion, cleaning up")
+		r.Log.V(1).Info("nodeobservabilitymachineconfig resource marked for deletion, cleaning up")
 		result, err = r.cleanUp(ctx, req)
 
 		if r.CtrlConfig.Status.IsMachineConfigInProgress() {
@@ -119,7 +117,7 @@ func (r *MachineConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Set finalizers on the NodeObservabilityMachineConfig resource
 	updated, err := r.addFinalizer(ctx, req)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update NodeObservabilityMachineConfig with finalizers: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to update nodeobservabilitymachineconfig with finalizers: %w", err)
 	}
 	updated.DeepCopyInto(r.CtrlConfig)
 
@@ -200,9 +198,9 @@ func (r *MachineConfigReconciler) cleanUp(ctx context.Context, req ctrl.Request)
 
 	if removeFinalizer && hasFinalizer(r.CtrlConfig) {
 		if _, err := r.removeFinalizer(ctx, req, finalizer); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from NodeObservabilityMachineConfig %s: %w", r.CtrlConfig.Name, err)
+			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from nodeobservabilitymachineconfig %s: %w", r.CtrlConfig.Name, err)
 		}
-		r.Log.V(1).Info("Removed finalizer from NodeObservabilityMachineConfig resource, cleanup complete")
+		r.Log.V(1).Info("Removed finalizer from nodeobservabilitymachineconfig resource, cleanup complete")
 	}
 
 	return ctrl.Result{}, nil
@@ -277,7 +275,7 @@ func (r *MachineConfigReconciler) updateStatus(ctx context.Context) error {
 
 	namespace := types.NamespacedName{Name: r.CtrlConfig.Name}
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		r.Log.V(1).Info("Updating NodeObservabilityMachineConfig status")
+		r.Log.V(1).Info("Updating nodeobservabilitymachineconfig status")
 		nomc := &v1alpha1.NodeObservabilityMachineConfig{}
 		if err := r.ClientGet(ctx, namespace, nomc); err != nil {
 			return err

--- a/pkg/operator/controller/machineconfig/controller.go
+++ b/pkg/operator/controller/machineconfig/controller.go
@@ -84,7 +84,8 @@ func (r *MachineConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if ctxLog, err := logr.FromContext(ctx); err == nil {
 		r.Log = ctxLog
 	}
-	r.Log.V(1).Info("reconciling", "request", req)
+
+	r.Log.V(1).Info("reconciliation started")
 
 	// Fetch the NodeObservabilityMachineConfig CR
 	r.CtrlConfig = &v1alpha1.NodeObservabilityMachineConfig{}

--- a/pkg/operator/controller/nodeobservability/configmap.go
+++ b/pkg/operator/controller/nodeobservability/configmap.go
@@ -58,9 +58,9 @@ func (r *NodeObservabilityReconciler) createConfigMap(ctx context.Context, nodeO
 			if err := r.Create(ctx, configMap); err != nil {
 				return fmt.Errorf("failed to create target configmap %q: %w", configMapName, err)
 			}
+			r.Log.Info("created kubelet CA configmap", "configmap.namespace", configMapName.Namespace, "configmap.name", configMapName.Name)
 		}
 	}
 
-	r.Log.Info("created kubelet CA configmap", "configmap.namespace", configMapName.Namespace, "configmap.name", configMapName.Name)
 	return nil
 }

--- a/pkg/operator/controller/nodeobservability/controller.go
+++ b/pkg/operator/controller/nodeobservability/controller.go
@@ -158,28 +158,28 @@ func (r *NodeObservabilityReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	} else if !haveSCC {
 		return ctrl.Result{}, fmt.Errorf("failed to get securitycontextconstraints")
 	}
-	r.Log.V(1).Info("SecurityContextConstraints ensured", "name", scc.Name)
+	r.Log.V(1).Info("securitycontextconstraint ensured", "scc.name", scc.Name)
 
 	// ensure serviceaccount
 	sa, err := r.ensureServiceAccount(ctx, nodeObs, r.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure serviceaccount : %w", err)
 	}
-	r.Log.V(1).Info("serviceaccount ensured", "namespace", sa.Namespace, "name", sa.Name)
+	r.Log.V(1).Info("serviceaccount ensured", "sa.namespace", sa.Namespace, "sa.name", sa.Name)
 
 	// ensure service
 	svc, err := r.ensureService(ctx, nodeObs, r.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure service : %w", err)
 	}
-	r.Log.V(1).Info("service ensured", "namespace", svc.Namespace, "name", svc.Name)
+	r.Log.V(1).Info("service ensured", "svc.namespace", svc.Namespace, "svc.name", svc.Name)
 
 	// check clusterrole
 	_, cr, err := r.ensureClusterRole(ctx, nodeObs)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure clusterrole : %w", err)
 	}
-	r.Log.V(1).Info("clusterrole ensured", "name", cr.Name)
+	r.Log.V(1).Info("clusterrole ensured", "clusterrole.name", cr.Name)
 
 	// check clusterolebinding with serviceaccount
 	haveCRB, crb, err := r.ensureClusterRoleBinding(ctx, nodeObs, sa.Name, r.Namespace)
@@ -188,14 +188,14 @@ func (r *NodeObservabilityReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	} else if !haveCRB {
 		return ctrl.Result{}, fmt.Errorf("failed to get clusterrolebinding")
 	}
-	r.Log.V(1).Info("ClusterRoleBinding ensured", "Name", crb.Name)
+	r.Log.V(1).Info("clusterrolebinding ensured", "clusterrolebinding.name", crb.Name)
 
 	// check daemonset
 	ds, err := r.ensureDaemonSet(ctx, nodeObs, sa, r.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure daemonset : %w", err)
 	}
-	r.Log.V(1).Info("daemonset ensured", "namespace", ds.Namespace, "name", ds.Name)
+	r.Log.V(1).Info("daemonset ensured", "ds.namespace", ds.Namespace, "ds.name", ds.Name)
 
 	dsReady := ds.Status.NumberReady == ds.Status.DesiredNumberScheduled
 
@@ -206,7 +206,7 @@ func (r *NodeObservabilityReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to ensure nodeobservabilitymachineconfig : %w", err)
 		}
-		r.Log.V(1).Info("nodeobservabilitymachineconfig ensured", "name", nomc.Name)
+		r.Log.V(1).Info("nodeobservabilitymachineconfig ensured", "nomc.name", nomc.Name)
 		nomcReady = nomc.Status.IsReady()
 	}
 

--- a/pkg/operator/controller/nodeobservability/controller.go
+++ b/pkg/operator/controller/nodeobservability/controller.go
@@ -71,10 +71,10 @@ type NodeObservabilityReconciler struct {
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=list;get;create;watch;delete;
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=list;get;create;watch;delete;
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=list;get;create;watch;use;delete;
-//+kubebuilder:rbac:groups=apps,namespace=node-observability-operator,resources=daemonsets,verbs=list;get;create;watch;
+//+kubebuilder:rbac:groups=apps,namespace=node-observability-operator,resources=daemonsets,verbs=list;get;create;watch;update;patch;
 //+kubebuilder:rbac:groups=core,namespace=node-observability-operator,resources=secrets,verbs=list;get;create;watch;delete;
-//+kubebuilder:rbac:groups=core,namespace=node-observability-operator,resources=services,verbs=list;get;create;watch;delete;
-//+kubebuilder:rbac:groups=core,namespace=node-observability-operator,resources=serviceaccounts,verbs=list;get;create;watch;delete;
+//+kubebuilder:rbac:groups=core,namespace=node-observability-operator,resources=services,verbs=list;get;create;watch;delete;update;patch;
+//+kubebuilder:rbac:groups=core,namespace=node-observability-operator,resources=serviceaccounts,verbs=list;get;create;watch;delete;update;patch;
 //+kubebuilder:rbac:groups=core,namespace=node-observability-operator,resources=configmaps,verbs=list;get;create;watch;delete;update;
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=node-observability-operator,resources=roles,verbs=list;get;create;watch;delete;
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=node-observability-operator,resources=rolebindings,verbs=list;get;create;watch;delete;

--- a/pkg/operator/controller/nodeobservability/controller.go
+++ b/pkg/operator/controller/nodeobservability/controller.go
@@ -157,34 +157,28 @@ func (r *NodeObservabilityReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	} else if !haveSCC {
 		return ctrl.Result{}, fmt.Errorf("failed to get securitycontextconstraints")
 	}
-	r.Log.V(1).Info("SecurityContextConstraints ensured", "Name", scc.Name)
+	r.Log.V(1).Info("SecurityContextConstraints ensured", "name", scc.Name)
 
 	// ensure serviceaccount
-	haveSA, sa, err := r.ensureServiceAccount(ctx, nodeObs, r.Namespace)
+	sa, err := r.ensureServiceAccount(ctx, nodeObs, r.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure serviceaccount : %w", err)
-	} else if !haveSA {
-		return ctrl.Result{}, fmt.Errorf("failed to get serviceaccount")
 	}
-	r.Log.V(1).Info("ServiceAccount ensured", "Namespace", sa.Namespace, "Name", sa.Name)
+	r.Log.V(1).Info("serviceaccount ensured", "namespace", sa.Namespace, "name", sa.Name)
 
 	// ensure service
-	haveSvc, svc, err := r.ensureService(ctx, nodeObs, r.Namespace)
+	svc, err := r.ensureService(ctx, nodeObs, r.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure service : %w", err)
-	} else if !haveSvc {
-		return ctrl.Result{}, fmt.Errorf("failed to get service")
 	}
-	r.Log.V(1).Info("Service ensured", "Namespace", svc.Namespace, "Name", svc.Name)
+	r.Log.V(1).Info("service ensured", "namespace", svc.Namespace, "name", svc.Name)
 
 	// check clusterrole
-	haveCR, cr, err := r.ensureClusterRole(ctx, nodeObs)
+	_, cr, err := r.ensureClusterRole(ctx, nodeObs)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure clusterrole : %w", err)
-	} else if !haveCR {
-		return ctrl.Result{}, fmt.Errorf("failed to get clusterrole")
 	}
-	r.Log.V(1).Info("ClusterRole ensured", "Name", cr.Name)
+	r.Log.V(1).Info("clusterrole ensured", "name", cr.Name)
 
 	// check clusterolebinding with serviceaccount
 	haveCRB, crb, err := r.ensureClusterRoleBinding(ctx, nodeObs, sa.Name, r.Namespace)
@@ -209,13 +203,11 @@ func (r *NodeObservabilityReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// if machine config change is not requested, we can mark it as ready
 	var nomcReady bool = true
 	if machineConfigChangeRequested(nodeObs) {
-		haveNOMC, nomc, err := r.ensureNOMC(ctx, nodeObs)
+		nomc, err := r.ensureNOMC(ctx, nodeObs, r.Namespace)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to ensure nodeobservabilitymachineconfig : %w", err)
-		} else if !haveNOMC {
-			return ctrl.Result{}, fmt.Errorf("failed to get nodeobservabilitymachineconfig")
 		}
-		r.Log.V(1).Info("NodeObservabilityMachineConfig ensured", "Name", nomc.Name)
+		r.Log.V(1).Info("nodeobservabilitymachineconfig ensured", "name", nomc.Name)
 		nomcReady = nomc.Status.IsReady()
 	}
 

--- a/pkg/operator/controller/nodeobservability/controller.go
+++ b/pkg/operator/controller/nodeobservability/controller.go
@@ -89,7 +89,7 @@ func (r *NodeObservabilityReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		r.Log = ctxLog
 	}
 
-	r.Log.V(3).Info("reconciling", "request", req)
+	r.Log.V(1).Info("reconciliation started")
 
 	// Fetch the NodeObservability instance
 	nodeObs := &operatorv1alpha1.NodeObservability{}

--- a/pkg/operator/controller/nodeobservability/controller.go
+++ b/pkg/operator/controller/nodeobservability/controller.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"fmt"
 
-	logr "github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	logr "github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -190,13 +191,11 @@ func (r *NodeObservabilityReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	r.Log.V(1).Info("ClusterRoleBinding ensured", "Name", crb.Name)
 
 	// check daemonset
-	haveDS, ds, err := r.ensureDaemonSet(ctx, nodeObs, sa, r.Namespace)
+	ds, err := r.ensureDaemonSet(ctx, nodeObs, sa, r.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure daemonset : %w", err)
-	} else if !haveDS {
-		return ctrl.Result{}, fmt.Errorf("failed to get daemonset")
 	}
-	r.Log.V(1).Info("DaemonSet ensured", "Namespace", ds.Namespace, "Name", ds.Name)
+	r.Log.V(1).Info("daemonset ensured", "namespace", ds.Namespace, "name", ds.Name)
 
 	dsReady := ds.Status.NumberReady == ds.Status.DesiredNumberScheduled
 

--- a/pkg/operator/controller/nodeobservability/controller_test.go
+++ b/pkg/operator/controller/nodeobservability/controller_test.go
@@ -122,9 +122,6 @@ func TestReconcile(t *testing.T) {
 			expectedResult:       reconcile.Result{},
 			expectReadyCondition: metav1.ConditionFalse,
 		},
-		{
-			name: "",
-		},
 	}
 
 	// loop through test cases (bootstrap and delete)

--- a/pkg/operator/controller/nodeobservability/controller_test.go
+++ b/pkg/operator/controller/nodeobservability/controller_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/google/go-cmp/cmp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -48,105 +49,6 @@ func TestReconcile(t *testing.T) {
 	}
 
 	eventWaitTimeout := time.Duration(1 * time.Second)
-
-	// used to simulate errors for all objects
-	ErrRuns := []ErrTestObject{
-		{
-			Enabled:  true,
-			Set:      nil,
-			NotFound: nil,
-		},
-		{
-			Enabled: true,
-			Set: map[string]bool{
-				sccObj: true,
-			},
-			NotFound: map[string]bool{
-				sccObj: false,
-			},
-		},
-		{
-			Enabled: true,
-			Set: map[string]bool{
-				saObj: true,
-			},
-			NotFound: map[string]bool{
-				saObj: false,
-			},
-		},
-		{
-			Enabled: true,
-			Set: map[string]bool{
-				crObj: true,
-			},
-			NotFound: map[string]bool{
-				crObj: false,
-			},
-		},
-		{
-			Enabled: true,
-			Set: map[string]bool{
-				crbObj: true,
-			},
-			NotFound: map[string]bool{
-				crbObj: false,
-			},
-		},
-		{
-			Enabled: true,
-			Set: map[string]bool{
-				dsObj: true,
-			},
-			NotFound: map[string]bool{
-				dsObj: false,
-			},
-		},
-		{
-			Enabled: true,
-			Set: map[string]bool{
-				sccObj: true,
-			},
-			NotFound: map[string]bool{
-				sccObj: true,
-			},
-		},
-		{
-			Enabled: true,
-			Set: map[string]bool{
-				saObj: true,
-			},
-			NotFound: map[string]bool{
-				saObj: true,
-			},
-		},
-		{
-			Enabled: true,
-			Set: map[string]bool{
-				crObj: true,
-			},
-			NotFound: map[string]bool{
-				crObj: true,
-			},
-		},
-		{
-			Enabled: true,
-			Set: map[string]bool{
-				crbObj: true,
-			},
-			NotFound: map[string]bool{
-				crbObj: true,
-			},
-		},
-		{
-			Enabled: true,
-			Set: map[string]bool{
-				dsObj: true,
-			},
-			NotFound: map[string]bool{
-				dsObj: true,
-			},
-		},
-	}
 
 	teAdd := test.Event{
 		EventType: watch.Added,
@@ -220,101 +122,93 @@ func TestReconcile(t *testing.T) {
 			expectedResult:       reconcile.Result{},
 			expectReadyCondition: metav1.ConditionFalse,
 		},
+		{
+			name: "",
+		},
 	}
 
 	// loop through test cases (bootstrap and delete)
 	for _, tc := range testCases {
-		// loop through error objects
-		for _, errTest := range ErrRuns {
-			// run the tests
-			t.Run(tc.name, func(t *testing.T) {
-				cl := fake.NewClientBuilder().WithScheme(test.Scheme).WithRuntimeObjects(tc.existingObjects...).Build()
-				// for each run we clear the expected Events
-				tc.expectedEvents = nil
+		// run the tests
+		t.Run(tc.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().WithScheme(test.Scheme).WithRuntimeObjects(tc.existingObjects...).Build()
+			// for each run we clear the expected Events
+			tc.expectedEvents = nil
 
-				r := &NodeObservabilityReconciler{
-					Client:            cl,
-					ClusterWideClient: cl,
-					Scheme:            test.Scheme,
-					Log:               zap.New(zap.UseDevMode(true)),
-					Err:               errTest,
-					AgentImage:        "test",
-				}
-				// only check for errors when the ErrorTestObject Set and NotFound maps are nill
-				tc.errExpected = (errTest.Set != nil || errTest.NotFound != nil) && tc.name == "Bootstrapping"
+			r := &NodeObservabilityReconciler{
+				Client:            cl,
+				ClusterWideClient: cl,
+				Scheme:            test.Scheme,
+				Log:               zap.New(zap.UseDevMode(true)),
+				AgentImage:        "test",
+			}
 
-				// the add and modify events should only be added when there are no 'simulated' errors
-				if (errTest.Set == nil && errTest.NotFound == nil) && tc.name == "Bootstrapping" {
-					//update finalizer
-					tc.expectedEvents = append(tc.expectedEvents, teMod)
-					//add daemonset
-					tc.expectedEvents = append(tc.expectedEvents, teAdd)
-					//update status
-					tc.expectedEvents = append(tc.expectedEvents, teMod)
-				}
-				if tc.name == "Deleting" {
-					//update finalizer
-					tc.expectedEvents = append(tc.expectedEvents, teDel)
-				}
-				if (errTest.Set != nil || errTest.NotFound != nil) && tc.name == "Bootstrapping" {
-					//update finalizer
-					tc.expectedEvents = append(tc.expectedEvents, teMod)
-				}
+			// the add and modify events should only be added when there are no 'simulated' errors
+			if tc.name == "Bootstrapping" {
+				//update finalizer
+				tc.expectedEvents = append(tc.expectedEvents, teMod)
+				//add daemonset
+				tc.expectedEvents = append(tc.expectedEvents, teAdd)
+				//update status
+				tc.expectedEvents = append(tc.expectedEvents, teMod)
+			}
+			if tc.name == "Deleting" {
+				//update finalizer
+				tc.expectedEvents = append(tc.expectedEvents, teDel)
+			}
+			if tc.name == "Bootstrapping" {
+				//update finalizer
+				tc.expectedEvents = append(tc.expectedEvents, teMod)
+			}
 
-				// special case for daemonset
-				if errTest.Set[dsObj] && tc.name == "Bootstrapping" {
-					tc.expectedEvents = append(tc.expectedEvents, teAdd)
-				}
+			c := test.NewEventCollector(t, cl, managedTypesList, len(tc.expectedEvents))
 
-				c := test.NewEventCollector(t, cl, managedTypesList, len(tc.expectedEvents))
+			ctx := context.TODO()
+			// get watch interfaces from all the types managed by the operator
+			c.Start(ctx)
+			defer c.Stop()
 
-				ctx := context.TODO()
-				// get watch interfaces from all the types managed by the operator
-				c.Start(ctx)
-				defer c.Stop()
+			// TEST FUNCTION
+			gotResult, err := r.Reconcile(ctx, tc.inputRequest)
 
-				// TEST FUNCTION
-				gotResult, err := r.Reconcile(ctx, tc.inputRequest)
-
-				res := &operatorv1alpha1.NodeObservability{}
-				if err := cl.Get(ctx, tc.inputRequest.NamespacedName, res); err != nil && !kerrors.IsNotFound(err) {
-					t.Fatalf("unexpected error while getting %v", tc.inputRequest.NamespacedName)
-				}
-				if err != nil { // nodeObs is found
-					cnd := res.Status.ConditionalStatus.GetCondition(operatorv1alpha1.DebugReady)
-					if cnd != nil {
-						isReady := cnd.Status
-						if tc.expectReadyCondition != isReady {
-							t.Fatalf("expecting condition Discarded %v but was %v", tc.expectReadyCondition, isReady)
-						}
+			res := &operatorv1alpha1.NodeObservability{}
+			if err := cl.Get(ctx, tc.inputRequest.NamespacedName, res); err != nil && !kerrors.IsNotFound(err) {
+				t.Fatalf("unexpected error while getting %v", tc.inputRequest.NamespacedName)
+			}
+			if err != nil { // nodeObs is found
+				cond := res.Status.ConditionalStatus.GetCondition(operatorv1alpha1.DebugReady)
+				if cond != nil {
+					isReady := cond.Status
+					if tc.expectReadyCondition != isReady {
+						t.Fatalf("expecting condition DebugRead=%v but was DebugReady=%v", tc.expectReadyCondition, isReady)
 					}
 				}
+			}
 
-				// error check
-				if err != nil {
-					if !tc.errExpected {
-						t.Fatalf("got unexpected error: %v", err)
-					}
-				} else if tc.errExpected {
-					t.Fatalf("error expected but not received")
+			// error check
+			if err != nil {
+				if !tc.errExpected {
+					t.Fatalf("got unexpected error: %v", err)
 				}
+			} else if tc.errExpected {
+				t.Fatalf("error expected but not received")
+			}
 
-				// result check
-				if !reflect.DeepEqual(gotResult, tc.expectedResult) {
-					t.Fatalf("expected result %v, got %v", tc.expectedResult, gotResult)
-				}
+			// result check
+			if !reflect.DeepEqual(gotResult, tc.expectedResult) {
+				t.Fatalf("expected result %v, got %v", tc.expectedResult, gotResult)
+			}
 
-				// collect the events received from Reconcile()
-				collectedEvents := c.Collect(len(tc.expectedEvents), eventWaitTimeout)
+			// collect the events received from Reconcile()
+			collectedEvents := c.Collect(len(tc.expectedEvents), eventWaitTimeout)
 
-				// compare collected and expected events
-				idxExpectedEvents := test.IndexEvents(tc.expectedEvents)
-				idxCollectedEvents := test.IndexEvents(collectedEvents)
-				if diff := cmp.Diff(idxExpectedEvents, idxCollectedEvents); diff != "" {
-					t.Fatalf("found diff between expected and collected events: %s", diff)
-				}
-			})
-		}
+			// compare collected and expected events
+			idxExpectedEvents := test.IndexEvents(tc.expectedEvents)
+			idxCollectedEvents := test.IndexEvents(collectedEvents)
+			if diff := cmp.Diff(idxExpectedEvents, idxCollectedEvents); diff != "" {
+				t.Fatalf("found diff between expected and collected events: %s", diff)
+			}
+		})
 	}
 }
 

--- a/pkg/operator/controller/nodeobservability/daemonset.go
+++ b/pkg/operator/controller/nodeobservability/daemonset.go
@@ -69,6 +69,7 @@ func (r *NodeObservabilityReconciler) ensureDaemonSet(ctx context.Context, nodeO
 		if err != nil {
 			return nil, fmt.Errorf("failed to get existing daemonset %q: %w", nameSpace, err)
 		}
+		r.Log.V(1).Info("successfully updated daemonset", "ds.name", nameSpace.Name, "ds.namespace", nameSpace.Namespace)
 	}
 	return current, nil
 }

--- a/pkg/operator/controller/nodeobservability/daemonset.go
+++ b/pkg/operator/controller/nodeobservability/daemonset.go
@@ -86,7 +86,7 @@ func (r *NodeObservabilityReconciler) createDaemonSet(ctx context.Context, ds *a
 	if err := r.Create(ctx, ds); err != nil {
 		return fmt.Errorf("failed to create daemonset %s/%s: %w", ds.Namespace, ds.Name, err)
 	}
-	r.Log.Info("created daemonset", "namespace", ds.Namespace, "name", ds.Name)
+	r.Log.V(1).Info("created daemonset", "ds.namespace", ds.Namespace, "ds.name", ds.Name)
 	return nil
 }
 

--- a/pkg/operator/controller/nodeobservability/daemonset.go
+++ b/pkg/operator/controller/nodeobservability/daemonset.go
@@ -9,6 +9,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	v1alpha1 "github.com/openshift/node-observability-operator/api/v1alpha1"
@@ -31,59 +34,114 @@ const (
 // ensureDaemonSet ensures that the daemonset exists
 // Returns a Boolean value indicating whether it exists, a pointer to the
 // daemonset and an error when relevant
-func (r *NodeObservabilityReconciler) ensureDaemonSet(ctx context.Context, nodeObs *v1alpha1.NodeObservability, sa *corev1.ServiceAccount, ns string) (bool, *appsv1.DaemonSet, error) {
+func (r *NodeObservabilityReconciler) ensureDaemonSet(ctx context.Context, nodeObs *v1alpha1.NodeObservability, sa *corev1.ServiceAccount, ns string) (*appsv1.DaemonSet, error) {
 	nameSpace := types.NamespacedName{Namespace: ns, Name: daemonSetName}
 	desired := r.desiredDaemonSet(nodeObs, sa, ns)
 	if err := controllerutil.SetControllerReference(nodeObs, desired, r.Scheme); err != nil {
-		return false, nil, fmt.Errorf("failed to set the controller reference for daemonset: %w", err)
+		return nil, fmt.Errorf("failed to set the controller reference for daemonset: %w", err)
 	}
-	exist, current, err := r.currentDaemonSet(ctx, nameSpace)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to get DaemonSet: %w", err)
-	}
-	if !exist {
-		cmExists, err := r.createConfigMap(ctx, nodeObs, ns)
+
+	current, err := r.currentDaemonSet(ctx, nameSpace)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get daemonset %s/%s due to: %w", nameSpace.Namespace, nameSpace.Namespace, err)
+	} else if err != nil && errors.IsNotFound(err) {
+
+		// create daemon since it doesn't exist
+		err := r.createConfigMap(ctx, nodeObs, ns)
 		if err != nil {
-			return false, nil, fmt.Errorf("failed to create the configMap for kubelet-serving-ca: %w", err)
+			return nil, fmt.Errorf("failed to create the configmap for kubelet-serving-ca: %w", err)
 		}
-		if !cmExists {
-			return false, nil, fmt.Errorf("failed to get the configMap for kubelet-serving-ca: %w", err)
-		}
+
 		if err := r.createDaemonSet(ctx, desired); err != nil {
-			return false, nil, err
+			return nil, err
 		}
 		return r.currentDaemonSet(ctx, nameSpace)
 	}
-	return true, current, err
+
+	updated, err := r.updateDaemonset(ctx, current, desired)
+	if err != nil {
+		return nil, err
+	}
+
+	if updated {
+		current, err = r.currentDaemonSet(ctx, nameSpace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get existing daemonset %s/%s: %w", nameSpace.Namespace, nameSpace.Name, err)
+		}
+	}
+	return current, nil
 }
 
 // currentDaemonSet check if the daemonset exists
-func (r *NodeObservabilityReconciler) currentDaemonSet(ctx context.Context, nameSpace types.NamespacedName) (bool, *appsv1.DaemonSet, error) {
+func (r *NodeObservabilityReconciler) currentDaemonSet(ctx context.Context, nameSpace types.NamespacedName) (*appsv1.DaemonSet, error) {
 	ds := &appsv1.DaemonSet{}
-	if err := r.Get(ctx, nameSpace, ds); err != nil || r.Err.Set[dsObj] {
-		if errors.IsNotFound(err) || r.Err.NotFound[dsObj] {
-			return false, nil, nil
-		}
-		if r.Err.Set[dsObj] {
-			err = fmt.Errorf("failed to get DaemonSet: simulated error")
-		}
-		return false, nil, err
+	if err := r.Get(ctx, nameSpace, ds); err != nil {
+		return nil, err
 	}
-	return true, ds, nil
+	return ds, nil
 }
 
 // createDaemonSet creates the serviceaccount
 func (r *NodeObservabilityReconciler) createDaemonSet(ctx context.Context, ds *appsv1.DaemonSet) error {
 	if err := r.Create(ctx, ds); err != nil {
-		return fmt.Errorf("failed to create DaemonSet %s/%s: %w", ds.Namespace, ds.Name, err)
+		return fmt.Errorf("failed to create daemonset %s/%s: %w", ds.Namespace, ds.Name, err)
 	}
-	r.Log.Info("created DaemonSet", "DaemonSet.Namespace", ds.Namespace, "DaemonSet.Name", ds.Name)
+	r.Log.Info("created daemonset", "namespace", ds.Namespace, "name", ds.Name)
 	return nil
+}
+
+func (r *NodeObservabilityReconciler) updateDaemonset(ctx context.Context, current, desired *appsv1.DaemonSet) (bool, error) {
+	updatedDS := current.DeepCopy()
+	updated := false
+
+	if !cmp.Equal(current.ObjectMeta.OwnerReferences, desired.ObjectMeta.OwnerReferences) {
+		updatedDS.ObjectMeta.OwnerReferences = desired.ObjectMeta.OwnerReferences
+		updated = true
+	}
+
+	// if the desired and current daemonset container are not the same then just update
+	if len(desired.Spec.Template.Spec.Containers) != len(updatedDS.Spec.Template.Spec.Containers) {
+		updatedDS.Spec.Template.Spec.Containers = desired.Spec.Template.Spec.Containers
+		updated = true
+	} else {
+		// for each of the container in the desired daemonset ensure the corresponding container in the current matches
+		for _, desiredContainer := range desired.Spec.Template.Spec.Containers {
+			foundIndex := -1
+			for i, currentContainer := range updatedDS.Spec.Template.Spec.Containers {
+				if currentContainer.Name == desiredContainer.Name {
+					foundIndex = i
+					break
+				}
+			}
+			if foundIndex < 0 {
+				return false, fmt.Errorf("daemonset %s does not have a container with the name %s", current.Name, desiredContainer.Name)
+			}
+
+			if changed := hasContainerChanged(updatedDS.Spec.Template.Spec.Containers[foundIndex], desiredContainer); changed {
+				updatedDS.Spec.Template.Spec.Containers[foundIndex] = desiredContainer
+				updated = true
+			}
+		}
+	}
+
+	if haveVolumesChanged(updatedDS.Spec.Template.Spec.Volumes, desired.Spec.Template.Spec.Volumes) {
+		updatedDS.Spec.Template.Spec.Volumes = desired.Spec.Template.Spec.Volumes
+		updated = true
+	}
+
+	if updated {
+		err := r.Update(ctx, updatedDS)
+		if err != nil {
+			return false, fmt.Errorf("failed to update existing daemonset %s: %w", updatedDS.Name, err)
+		}
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // desiredDaemonSet returns a DaemonSet object
 func (r *NodeObservabilityReconciler) desiredDaemonSet(nodeObs *v1alpha1.NodeObservability, sa *corev1.ServiceAccount, ns string) *appsv1.DaemonSet {
-
 	ls := labelsForNodeObservability(nodeObs.Name)
 	tgp := int64(30)
 	vst := corev1.HostPathSocket
@@ -119,14 +177,16 @@ func (r *NodeObservabilityReconciler) desiredDaemonSet(nodeObs *v1alpha1.NodeObs
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &privileged,
 							},
-							Env: []corev1.EnvVar{{
-								Name: "NODE_IP",
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: "status.hostIP",
+							Env: []corev1.EnvVar{
+								{
+									Name: "NODE_IP",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "status.hostIP",
+										},
 									},
 								},
-							}},
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									MountPath: socketMountPath,
@@ -207,4 +267,137 @@ func (r *NodeObservabilityReconciler) desiredDaemonSet(nodeObs *v1alpha1.NodeObs
 // belonging to the given node observability CR name.
 func labelsForNodeObservability(name string) map[string]string {
 	return map[string]string{"app": "nodeobservability", "nodeobs_cr": name}
+}
+
+// haveVolumesChanged if the current volumes differs from the desired volumes
+func haveVolumesChanged(current []corev1.Volume, desired []corev1.Volume) bool {
+	if len(current) != len(desired) {
+		return true
+	}
+	for i := 0; i < len(current); i++ {
+		cv := current[i]
+		dv := desired[i]
+		if cv.Name != dv.Name {
+			return true
+		}
+		if dv.Secret != nil {
+			if cv.Secret == nil {
+				return true
+			}
+			if cv.Secret.SecretName != dv.Secret.SecretName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasContainerChanged checks if the current container differs from the
+// desired container
+func hasContainerChanged(current, desired corev1.Container) bool {
+	if current.Image != desired.Image {
+		return true
+	}
+	if !cmp.Equal(current.Args, desired.Args) {
+		return true
+	}
+
+	if hasSecurityContextChanged(current.SecurityContext, desired.SecurityContext) {
+		return true
+	}
+
+	if len(current.Env) != len(desired.Env) {
+		return true
+	}
+	currentEnvs := indexedContainerEnv(current.Env)
+	for _, e := range desired.Env {
+		if ce, ok := currentEnvs[e.Name]; !ok {
+			return true
+		} else if !cmp.Equal(ce, e) {
+			return true
+		}
+	}
+
+	if len(current.VolumeMounts) != len(desired.VolumeMounts) {
+		return true
+	}
+
+	for i := 0; i < len(current.VolumeMounts); i++ {
+		cvm := current.VolumeMounts[i]
+		dvm := desired.VolumeMounts[i]
+		if cvm.Name != dvm.Name || cvm.MountPath != dvm.MountPath {
+			return true
+		}
+	}
+
+	return false
+}
+
+func indexedContainerEnv(envs []corev1.EnvVar) map[string]corev1.EnvVar {
+	indexed := make(map[string]corev1.EnvVar)
+	for _, e := range envs {
+		indexed[e.Name] = e
+	}
+	return indexed
+}
+
+func hasSecurityContextChanged(current, desired *corev1.SecurityContext) bool {
+	if desired == nil {
+		return false
+	}
+
+	if current == nil {
+		return true
+	}
+
+	if desired.Capabilities != nil {
+		if current.Capabilities == nil {
+			return true
+		}
+
+		cmpCapabilities := cmpopts.SortSlices(func(a, b corev1.Capability) bool { return a < b })
+		if !cmp.Equal(desired.Capabilities.Add, current.Capabilities.Add, cmpCapabilities) {
+			return true
+		}
+
+		if !cmp.Equal(desired.Capabilities.Drop, current.Capabilities.Drop, cmpCapabilities) {
+			return true
+		}
+	}
+
+	if !equalBoolPtr(current.RunAsNonRoot, desired.RunAsNonRoot) {
+		return true
+	}
+
+	if !equalBoolPtr(current.Privileged, desired.Privileged) {
+		return true
+	}
+	if !equalBoolPtr(current.AllowPrivilegeEscalation, desired.AllowPrivilegeEscalation) {
+		return true
+	}
+
+	if desired.SeccompProfile != nil {
+		if current.SeccompProfile == nil {
+			return true
+		}
+		if desired.SeccompProfile.Type != "" && desired.SeccompProfile.Type != current.SeccompProfile.Type {
+			return true
+		}
+	}
+	return false
+}
+
+func equalBoolPtr(current, desired *bool) bool {
+	if desired == nil {
+		return true
+	}
+
+	if current == nil {
+		return false
+	}
+
+	if *current != *desired {
+		return false
+	}
+	return true
 }

--- a/pkg/operator/controller/nodeobservability/daemonset_test.go
+++ b/pkg/operator/controller/nodeobservability/daemonset_test.go
@@ -668,9 +668,6 @@ func TestUpdateDaemonSet(t *testing.T) {
 					testContainer("agent", "agent:v1").
 						withArgs([]string{"--arg1=1"}...).
 						build(),
-					testContainer("random-container", "agent:v1").
-						withArgs([]string{"--arg1=1"}...).
-						build(),
 				).build(),
 			expectedDaemonset: testDaemonset("daemonset", "test-namespace", "test-sa").
 				withContainers(
@@ -704,7 +701,7 @@ func TestUpdateDaemonSet(t *testing.T) {
 			expectUpdate: true,
 		},
 		{
-			name: "container volume mount modified",
+			name: "container volume mount modified and new volume mount injected",
 			existingDaemonset: testDaemonset("daemonset", "test-namespace", "test-sa").
 				withContainers(testContainer("agent", "agent:v1").
 					withVolumeMounts([]corev1.VolumeMount{
@@ -727,7 +724,7 @@ func TestUpdateDaemonSet(t *testing.T) {
 			expectUpdate: true,
 		},
 		{
-			name: "daemonset volumes modified",
+			name: "daemonset volumes modified and new volume injected",
 			existingDaemonset: testDaemonset("daemonset", "test-namespace", "test-sa").
 				withContainers(
 					testContainer("agent", "agent:v1").build()).
@@ -736,7 +733,7 @@ func TestUpdateDaemonSet(t *testing.T) {
 						Name: "volume",
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: "random-secret",
+								SecretName: "secret",
 							},
 						},
 					},
@@ -759,14 +756,6 @@ func TestUpdateDaemonSet(t *testing.T) {
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
 								SecretName: "secret",
-							},
-						},
-					},
-					{
-						Name: "random-volume",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: "random-secret",
 							},
 						},
 					},
@@ -794,7 +783,7 @@ func TestUpdateDaemonSet(t *testing.T) {
 					},
 				}...).
 				build(),
-			expectUpdate: true,
+			expectUpdate: false,
 		},
 		{
 			name: "security context is modified",

--- a/pkg/operator/controller/nodeobservability/daemonset_test.go
+++ b/pkg/operator/controller/nodeobservability/daemonset_test.go
@@ -542,7 +542,7 @@ func TestEnsureDaemonset(t *testing.T) {
 			nodeObs := &operatorv1alpha1.NodeObservability{
 				ObjectMeta: metav1.ObjectMeta{Name: nodeObsInstanceName},
 				Spec: operatorv1alpha1.NodeObservabilitySpec{
-					Labels: map[string]string{
+					NodeSelector: map[string]string{
 						"node-role.kubernetes.io/worker": "",
 					},
 				},

--- a/pkg/operator/controller/nodeobservability/daemonset_util.go
+++ b/pkg/operator/controller/nodeobservability/daemonset_util.go
@@ -1,0 +1,240 @@
+package nodeobservabilitycontroller
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// indexedVolumeMount is the standard core volume mount with additional index field
+type indexedVolumeMount struct {
+	corev1.VolumeMount
+	Index int
+}
+
+// indexedContainer is the standard core container with additional index field
+type indexedContainer struct {
+	corev1.Container
+	Index int
+}
+
+// indexedVolume is the standard core volume with additional index field
+type indexedVolume struct {
+	corev1.Volume
+	Index int
+}
+
+// labelsForNodeObservability returns the labels for selecting the resources
+// belonging to the given node observability CR name.
+func labelsForNodeObservability(name string) map[string]string {
+	return map[string]string{"app": "nodeobservability", "nodeobs_cr": name}
+}
+
+// buildIndexedVolumeMountMap builds a map from the given list of volume mounts,
+// key is the volume name,
+// value is the indexed volume mount with the index being the sequence number of the given list.
+func buildIndexedVolumeMountMap(volumeMounts []corev1.VolumeMount) map[string]indexedVolumeMount {
+	m := map[string]indexedVolumeMount{}
+	for i, vol := range volumeMounts {
+		m[vol.Name] = indexedVolumeMount{
+			VolumeMount: vol,
+			Index:       i,
+		}
+	}
+	return m
+}
+
+// volumeMountsChanged checks that the current volume mounts have all expected ones,
+// returns true if the current volume mounts had to be changed to match the expected.
+func volumeMountsChanged(current, expected []corev1.VolumeMount) (bool, []corev1.VolumeMount) {
+	updated := make([]corev1.VolumeMount, len(expected))
+	copy(updated, expected)
+
+	if len(current) == 0 {
+		if len(expected) == 0 {
+			return false, updated
+		}
+		return true, expected
+	}
+
+	changed := false
+
+	currentVolumeMountMap := buildIndexedVolumeMountMap(current)
+	expectedVolumeMountMap := buildIndexedVolumeMountMap(expected)
+
+	// ensure all expected volume mounts are present,
+	// unsolicited ones are kept (e.g. kube api token)
+	for currName, currVol := range currentVolumeMountMap {
+		if expVol, expExists := expectedVolumeMountMap[currName]; !expExists {
+			updated = append(updated, currVol.VolumeMount)
+			changed = true
+		} else {
+			if !reflect.DeepEqual(currVol.VolumeMount, expVol.VolumeMount) {
+				updated[expVol.Index] = expVol.VolumeMount
+				changed = true
+			}
+		}
+	}
+
+	return changed, updated
+}
+
+// value is the indexed volume with the index being the sequence number of the given list.
+func buildIndexedVolumeMap(volumes []corev1.Volume) map[string]indexedVolume {
+	m := map[string]indexedVolume{}
+	for i, vol := range volumes {
+		m[vol.Name] = indexedVolume{
+			Volume: vol,
+			Index:  i,
+		}
+	}
+	return m
+}
+
+// volumeMountsChanged checks that the current volume have all expected volumes,
+// returns true if the current volumes had to be changed to match the expected.
+func volumesChanged(current []corev1.Volume, desired []corev1.Volume) (bool, []corev1.Volume) {
+	updated := make([]corev1.Volume, len(desired))
+	copy(updated, desired)
+
+	if len(current) == 0 {
+		if len(desired) == 0 {
+			return false, nil
+		}
+		updated = desired
+		return true, updated
+	}
+
+	changed := false
+
+	currentVolumeMap := buildIndexedVolumeMap(current)
+	expectedVolumeMap := buildIndexedVolumeMap(desired)
+
+	// ensure all expected volumes are present,
+	// unsolicited ones are kept (e.g. kube api token)
+	for expName, expVol := range expectedVolumeMap {
+		if currVol, currExists := currentVolumeMap[expName]; !currExists {
+			updated = append(updated, expVol.Volume)
+			changed = true
+		} else {
+			// deepequal is fine here as we don't have more than 1 item
+			// neither in the secret nor in the configmap
+			if !reflect.DeepEqual(currVol.Volume, expVol.Volume) {
+				updated[currVol.Index] = expVol.Volume
+				changed = true
+			}
+		}
+	}
+
+	return changed, updated
+}
+
+// equalEnvVars returns true if 2 env variable slices have the same content (order doesn't matter).
+func equalEnvVars(current, expected []corev1.EnvVar) bool {
+	var currentSorted, expectedSorted []string
+	for _, env := range current {
+		currentSorted = append(currentSorted, env.Name+" "+env.Value)
+	}
+	for _, env := range expected {
+		expectedSorted = append(expectedSorted, env.Name+" "+env.Value)
+	}
+	sort.Strings(currentSorted)
+	sort.Strings(expectedSorted)
+	return cmp.Equal(currentSorted, expectedSorted)
+}
+
+// buildIndexedContainerMap builds a map from the given list of containers,
+// key is the container name,
+// value is the indexed container with the index being the sequence number of the given list.
+func buildIndexedContainerMap(containers []corev1.Container) map[string]indexedContainer {
+	m := map[string]indexedContainer{}
+	for i, cont := range containers {
+		m[cont.Name] = indexedContainer{
+			Container: cont,
+			Index:     i,
+		}
+	}
+	return m
+}
+
+// containersChanged checks that the current containers have all expected containers,
+// returns true if the current containers had to be changed to match the expected.
+func containersChanged(current, desired []corev1.Container) (bool, []corev1.Container) {
+	changed := false
+
+	updatedContainers := make([]corev1.Container, len(desired))
+	copy(updatedContainers, desired)
+
+	currentContMap := buildIndexedContainerMap(current)
+	desiredContMap := buildIndexedContainerMap(desired)
+
+	// let's check that all the current containers have the desired values set
+	for currName, currCont := range currentContMap {
+		// if the current container is expected: check its fields
+		if expCont, found := desiredContMap[currName]; found {
+			if currCont.Image != expCont.Image {
+				updatedContainers[currCont.Index].Image = expCont.Image
+				changed = true
+			}
+			cmpOpts := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+			if !cmp.Equal(currCont.Args, expCont.Args, cmpOpts) {
+				updatedContainers[currCont.Index].Args = expCont.Args
+				changed = true
+			}
+			if !cmp.Equal(currCont.Command, expCont.Command, cmpOpts) {
+				updatedContainers[currCont.Index].Command = expCont.Command
+				changed = true
+			}
+			if !equalEnvVars(currCont.Env, expCont.Env) {
+				updatedContainers[currCont.Index].Env = expCont.Env
+				changed = true
+			}
+			if vmChanged, updatedVolumeMounts := volumeMountsChanged(currCont.VolumeMounts, expCont.VolumeMounts); vmChanged {
+				updatedContainers[currCont.Index].VolumeMounts = updatedVolumeMounts
+				changed = true
+			}
+			if hasSecurityContextChanged(currCont.SecurityContext, expCont.SecurityContext) {
+				updatedContainers[currCont.Index].SecurityContext = expCont.SecurityContext
+				changed = true
+			}
+
+		} else {
+			// if the current container is not expected: let's not dig deeper - reset all
+			updatedContainers = append(updatedContainers, currentContMap[currName].Container)
+			changed = false
+		}
+	}
+
+	return changed, updatedContainers
+}
+
+func hasSecurityContextChanged(current, desired *corev1.SecurityContext) bool {
+	if desired == nil {
+		return false
+	}
+
+	if current == nil {
+		return true
+	}
+
+	if !equalBoolPtr(current.Privileged, desired.Privileged) {
+		return true
+	}
+
+	return false
+}
+
+func equalBoolPtr(current, desired *bool) bool {
+	if desired == nil {
+		return true
+	}
+
+	if current == nil {
+		return false
+	}
+
+	return *current == *desired
+}

--- a/pkg/operator/controller/nodeobservability/daemonset_util.go
+++ b/pkg/operator/controller/nodeobservability/daemonset_util.go
@@ -184,7 +184,7 @@ func containersChanged(current, desired []corev1.Container) (bool, []corev1.Cont
 				updatedContainers[currCont.Index].Args = expCont.Args
 				changed = true
 			}
-			if !cmp.Equal(currCont.Command, expCont.Command, cmpOpts) {
+			if !cmp.Equal(currCont.Command, expCont.Command) {
 				updatedContainers[currCont.Index].Command = expCont.Command
 				changed = true
 			}
@@ -202,7 +202,6 @@ func containersChanged(current, desired []corev1.Container) (bool, []corev1.Cont
 			}
 
 		} else {
-			// if the current container is not expected: let's not dig deeper - reset all
 			updatedContainers = append(updatedContainers, currentContMap[currName].Container)
 			changed = false
 		}
@@ -220,11 +219,7 @@ func hasSecurityContextChanged(current, desired *corev1.SecurityContext) bool {
 		return true
 	}
 
-	if !equalBoolPtr(current.Privileged, desired.Privileged) {
-		return true
-	}
-
-	return false
+	return !equalBoolPtr(current.Privileged, desired.Privileged)
 }
 
 func equalBoolPtr(current, desired *bool) bool {

--- a/pkg/operator/controller/nodeobservability/mco.go
+++ b/pkg/operator/controller/nodeobservability/mco.go
@@ -78,7 +78,7 @@ func (r *NodeObservabilityReconciler) createNOMC(ctx context.Context, instance *
 	if err := r.Create(ctx, instance); err != nil {
 		return fmt.Errorf("failed to create nomc %s/%s: %w", instance.Namespace, instance.Name, err)
 	}
-	r.Log.Info("created nomc", "namespace", instance.Namespace, "name", instance.Name)
+	r.Log.V(1).Info("created nomc", "nomc.namespace", instance.Namespace, "nomc.name", instance.Name)
 	return nil
 }
 
@@ -125,6 +125,6 @@ func (r *NodeObservabilityReconciler) deleteNOMC(ctx context.Context, nodeObs *v
 		}
 		return fmt.Errorf("failed to delete nomc %s/%s: %w", mc.Namespace, mc.Name, err)
 	}
-	r.Log.Info("deleted nomc", "name", mc.Name)
+	r.Log.V(1).Info("deleted nomc", "nomc.name", mc.Name)
 	return nil
 }

--- a/pkg/operator/controller/nodeobservability/mco.go
+++ b/pkg/operator/controller/nodeobservability/mco.go
@@ -23,37 +23,42 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
-	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/node-observability-operator/api/v1alpha1"
 )
 
-func (r *NodeObservabilityReconciler) ensureNOMC(ctx context.Context, instance *v1alpha1.NodeObservability) (bool, *v1alpha1.NodeObservabilityMachineConfig, error) {
+func (r *NodeObservabilityReconciler) ensureNOMC(ctx context.Context, instance *v1alpha1.NodeObservability, ns string) (*v1alpha1.NodeObservabilityMachineConfig, error) {
+	nameSpace := types.NamespacedName{Name: instance.Name, Namespace: ns}
+
 	desired := r.desiredNOMC(instance)
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		_, corErr := ctrlutil.CreateOrUpdate(ctx, r.Client, desired, func() error {
-			desired.Spec = r.desiredNOMCSpec(instance)
-			return ctrlutil.SetControllerReference(instance, desired, r.Scheme)
-		})
-		return corErr
-	})
-	if err != nil {
-		return false, nil, err
+	if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
+		return nil, fmt.Errorf("failed to set the controller reference for nomc %q: %w", nameSpace.Name, err)
 	}
-	return r.currentNOMC(ctx, types.NamespacedName{Name: instance.Name})
+
+	currentNOMC, err := r.currentNOMC(ctx, nameSpace)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get nomc %s/%s due to: %w", nameSpace.Namespace, nameSpace.Name, err)
+	} else if err != nil && errors.IsNotFound(err) {
+
+		// create NOMC since it doesn't exist
+		if err := r.createNOMC(ctx, desired); err != nil {
+			return nil, err
+		}
+		return r.currentNOMC(ctx, nameSpace)
+	}
+
+	return r.updateNOMC(ctx, currentNOMC, desired)
 }
 
 // currentNOMC checks if the NodeObservabilityMachineConfig exists
-func (r *NodeObservabilityReconciler) currentNOMC(ctx context.Context, nameSpace types.NamespacedName) (bool, *v1alpha1.NodeObservabilityMachineConfig, error) {
+func (r *NodeObservabilityReconciler) currentNOMC(ctx context.Context, nameSpace types.NamespacedName) (*v1alpha1.NodeObservabilityMachineConfig, error) {
 	mc := &v1alpha1.NodeObservabilityMachineConfig{}
 	if err := r.Get(ctx, nameSpace, mc); err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil, nil
-		}
-		return false, nil, err
+		return nil, err
 	}
-	return true, mc, nil
+	return mc, nil
 }
 
 // desiredNOMC returns a NodeObservabilityMachineConfig object
@@ -64,6 +69,15 @@ func (r *NodeObservabilityReconciler) desiredNOMC(instance *v1alpha1.NodeObserva
 		},
 		Spec: r.desiredNOMCSpec(instance),
 	}
+}
+
+// createNOMC creates the NodeObservabilityMachineConfig
+func (r *NodeObservabilityReconciler) createNOMC(ctx context.Context, instance *v1alpha1.NodeObservabilityMachineConfig) error {
+	if err := r.Create(ctx, instance); err != nil {
+		return fmt.Errorf("failed to create nomc %s/%s: %w", instance.Namespace, instance.Name, err)
+	}
+	r.Log.Info("created nomc", "namespace", instance.Namespace, "name", instance.Name)
+	return nil
 }
 
 // desiredNOMCSpec returns a NodeObservabilityMachineConfigSpec object
@@ -79,6 +93,27 @@ func (r *NodeObservabilityReconciler) desiredNOMCSpec(instance *v1alpha1.NodeObs
 	return s
 }
 
+func (r *NodeObservabilityReconciler) updateNOMC(ctx context.Context, current, desired *v1alpha1.NodeObservabilityMachineConfig) (*v1alpha1.NodeObservabilityMachineConfig, error) {
+	updatedNOMC := current.DeepCopy()
+	updated := false
+
+	if !cmp.Equal(current.ObjectMeta.OwnerReferences, desired.ObjectMeta.OwnerReferences) {
+		updatedNOMC.ObjectMeta.OwnerReferences = desired.ObjectMeta.OwnerReferences
+		updated = true
+	}
+
+	if current.Spec.Debug.EnableCrioProfiling != desired.Spec.Debug.EnableCrioProfiling {
+		updatedNOMC.Spec.Debug.EnableCrioProfiling = desired.Spec.Debug.EnableCrioProfiling
+		updated = true
+	}
+
+	if updated {
+		return updatedNOMC, r.Update(ctx, updatedNOMC)
+	}
+
+	return updatedNOMC, nil
+}
+
 func (r *NodeObservabilityReconciler) deleteNOMC(ctx context.Context, nodeObs *v1alpha1.NodeObservability) error {
 	mc := &v1alpha1.NodeObservabilityMachineConfig{}
 	mc.Name = nodeObs.Name
@@ -86,8 +121,8 @@ func (r *NodeObservabilityReconciler) deleteNOMC(ctx context.Context, nodeObs *v
 		if errors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to delete NodeObservabilityMachineConfig %s: %w", mc.Name, err)
+		return fmt.Errorf("failed to delete nomc %s/%s: %w", mc.Namespace, mc.Name, err)
 	}
-	r.Log.Info("Deleted NodeObservabilityMachinConfig", "name", mc.Name)
+	r.Log.Info("deleted nomc", "name", mc.Name)
 	return nil
 }

--- a/pkg/operator/controller/nodeobservability/mco.go
+++ b/pkg/operator/controller/nodeobservability/mco.go
@@ -23,16 +23,17 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
 	"github.com/openshift/node-observability-operator/api/v1alpha1"
 )
 
 func (r *NodeObservabilityReconciler) ensureNOMC(ctx context.Context, instance *v1alpha1.NodeObservability, ns string) (*v1alpha1.NodeObservabilityMachineConfig, error) {
 	nameSpace := types.NamespacedName{Name: instance.Name, Namespace: ns}
 
-	desired := r.desiredNOMC(instance)
+	desired := r.desiredNOMC(instance, nameSpace)
 	if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
 		return nil, fmt.Errorf("failed to set the controller reference for nomc %q: %w", nameSpace.Name, err)
 	}
@@ -62,10 +63,11 @@ func (r *NodeObservabilityReconciler) currentNOMC(ctx context.Context, nameSpace
 }
 
 // desiredNOMC returns a NodeObservabilityMachineConfig object
-func (r *NodeObservabilityReconciler) desiredNOMC(instance *v1alpha1.NodeObservability) *v1alpha1.NodeObservabilityMachineConfig {
+func (r *NodeObservabilityReconciler) desiredNOMC(instance *v1alpha1.NodeObservability, nameSpace types.NamespacedName) *v1alpha1.NodeObservabilityMachineConfig {
 	return &v1alpha1.NodeObservabilityMachineConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: instance.Name,
+			Name:      instance.Name,
+			Namespace: nameSpace.Namespace,
 		},
 		Spec: r.desiredNOMCSpec(instance),
 	}

--- a/pkg/operator/controller/nodeobservability/mco_test.go
+++ b/pkg/operator/controller/nodeobservability/mco_test.go
@@ -67,8 +67,7 @@ func TestEnsureMCO(t *testing.T) {
 			existingObjects: []runtime.Object{
 				nomc,
 			},
-			expectedExist: true,
-			expectedMCO:   nomc,
+			expectedMCO: nomc,
 		},
 	}
 	for _, tc := range testCases {
@@ -80,7 +79,7 @@ func TestEnsureMCO(t *testing.T) {
 				Log:    zap.New(zap.UseDevMode(true)),
 			}
 
-			gotExist, obj, err := r.ensureNOMC(context.TODO(), nodeObs)
+			obj, err := r.ensureNOMC(context.TODO(), nodeObs, test.TestNamespace)
 			if err != nil {
 				if !tc.errExpected {
 					t.Fatalf("unexpected error received: %v", err)
@@ -91,10 +90,10 @@ func TestEnsureMCO(t *testing.T) {
 			if tc.errExpected {
 				t.Fatalf("Error expected but wasn't received")
 			}
-			if gotExist != tc.expectedExist {
-				t.Errorf("expected machineconfig exist to be %t, got %t", tc.expectedExist, gotExist)
-			}
-			if gotExist {
+
+			t.Log(obj)
+
+			if obj != nil {
 				for _, ref := range obj.GetOwnerReferences() {
 					if ref.Name == NodeObservabilityMachineConfigTest {
 						return

--- a/pkg/operator/controller/nodeobservability/mco_test.go
+++ b/pkg/operator/controller/nodeobservability/mco_test.go
@@ -90,7 +90,7 @@ func TestEnsureMCO(t *testing.T) {
 				Log:    zap.New(zap.UseDevMode(true)),
 			}
 
-			obj, err := r.ensureNOMC(context.TODO(), nodeObs, test.TestNamespace)
+			obj, err := r.ensureNOMC(context.TODO(), nodeObs)
 			if err != nil {
 				t.Fatalf("unexpected error received: %v", err)
 			}

--- a/pkg/operator/controller/nodeobservability/rbac_test.go
+++ b/pkg/operator/controller/nodeobservability/rbac_test.go
@@ -280,7 +280,7 @@ func TestEnsureClusterRole(t *testing.T) {
 				Log:    zap.New(zap.UseDevMode(true)),
 			}
 			nodeObs := &operatorv1alpha1.NodeObservability{}
-			_, serviceAccount, err := r.ensureServiceAccount(context.TODO(), nodeObs, test.TestNamespace)
+			serviceAccount, err := r.ensureServiceAccount(context.TODO(), nodeObs, test.TestNamespace)
 			if err != nil {
 				if !tc.errExpected {
 					t.Fatalf("unexpected error received: %v", err)

--- a/pkg/operator/controller/nodeobservability/service.go
+++ b/pkg/operator/controller/nodeobservability/service.go
@@ -13,10 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/google/go-cmp/cmp"
 	v1alpha1 "github.com/openshift/node-observability-operator/api/v1alpha1"
 )
 
@@ -91,6 +91,7 @@ func (r *NodeObservabilityReconciler) updateService(ctx context.Context, current
 		updatedService.Spec.Ports = desired.Spec.Ports
 		updated = true
 	}
+
 	if !equality.Semantic.DeepEqual(updatedService.Spec.Selector, desired.Spec.Selector) {
 		updatedService.Spec.Selector = desired.Spec.Selector
 		updated = true
@@ -129,6 +130,7 @@ func (r *NodeObservabilityReconciler) desiredService(nodeObs *v1alpha1.NodeObser
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,
+			Type:      corev1.ServiceTypeClusterIP,
 			Selector:  ls,
 			Ports: []corev1.ServicePort{
 				{

--- a/pkg/operator/controller/nodeobservability/service.go
+++ b/pkg/operator/controller/nodeobservability/service.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1alpha1 "github.com/openshift/node-observability-operator/api/v1alpha1"
 )
@@ -52,7 +51,7 @@ func (r *NodeObservabilityReconciler) ensureService(ctx context.Context, nodeObs
 		if err := r.createService(ctx, desired); err != nil {
 			return nil, err
 		}
-		log.FromContext(ctx).Info("successfully created service", "name", nameSpace.Name, "namespace", nameSpace.Namespace)
+		r.Log.V(1).Info("successfully created service", "svc.name", nameSpace.Name, "svc.namespace", nameSpace.Namespace)
 		return r.currentService(ctx, nameSpace)
 	}
 
@@ -74,7 +73,7 @@ func (r *NodeObservabilityReconciler) createService(ctx context.Context, svc *co
 	if err := r.Create(ctx, svc); err != nil {
 		return fmt.Errorf("failed to create service %s/%s: %w", svc.Namespace, svc.Name, err)
 	}
-	r.Log.Info("created service", "service.Namespace", svc.Namespace, "service.Name", svc.Name)
+	r.Log.V(1).Info("created service", "svc.Namespace", svc.Namespace, "svc.Name", svc.Name)
 	return nil
 }
 

--- a/pkg/operator/controller/nodeobservability/service.go
+++ b/pkg/operator/controller/nodeobservability/service.go
@@ -3,13 +3,20 @@ package nodeobservabilitycontroller
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/google/go-cmp/cmp"
 	v1alpha1 "github.com/openshift/node-observability-operator/api/v1alpha1"
 )
 
@@ -28,44 +35,86 @@ var (
 // ensureService ensures that the service exists
 // Returns a Boolean value indicating whether it exists, a pointer to the
 // service and an error when relevant
-func (r *NodeObservabilityReconciler) ensureService(ctx context.Context, nodeObs *v1alpha1.NodeObservability, ns string) (bool, *corev1.Service, error) {
+func (r *NodeObservabilityReconciler) ensureService(ctx context.Context, nodeObs *v1alpha1.NodeObservability, ns string) (*corev1.Service, error) {
 	nameSpace := types.NamespacedName{Namespace: ns, Name: serviceName}
+
 	desired := r.desiredService(nodeObs, ns)
-	exist, current, err := r.currentService(ctx, nameSpace)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to get Service: %v", err)
+	if err := controllerutil.SetControllerReference(nodeObs, desired, r.Scheme); err != nil {
+		return nil, fmt.Errorf("failed to set the controller reference for service %q: %w", nameSpace.Name, err)
 	}
-	if !exist {
+
+	current, err := r.currentService(ctx, nameSpace)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get service %s/%s due to: %w", nameSpace.Namespace, nameSpace.Name, err)
+	} else if err != nil && errors.IsNotFound(err) {
+
+		// creating service since it is not found
 		if err := r.createService(ctx, desired); err != nil {
-			return false, nil, err
+			return nil, err
 		}
+		log.FromContext(ctx).Info("successfully created service", "name", nameSpace.Name, "namespace", nameSpace.Namespace)
 		return r.currentService(ctx, nameSpace)
 	}
-	return true, current, err
+
+	// update service since it already exists
+	return r.updateService(ctx, current, desired)
 }
 
 // currentService checks that the service exists
-func (r *NodeObservabilityReconciler) currentService(ctx context.Context, nameSpace types.NamespacedName) (bool, *corev1.Service, error) {
+func (r *NodeObservabilityReconciler) currentService(ctx context.Context, nameSpace types.NamespacedName) (*corev1.Service, error) {
 	svc := &corev1.Service{}
-	if err := r.Get(ctx, nameSpace, svc); err != nil || r.Err.Set[svcObj] {
-		if errors.IsNotFound(err) || r.Err.NotFound[svcObj] {
-			return false, nil, nil
-		}
-		if r.Err.Set[svcObj] {
-			err = fmt.Errorf("failed to get Service: simulated error")
-		}
-		return false, nil, err
+	if err := r.Get(ctx, nameSpace, svc); err != nil {
+		return nil, fmt.Errorf("failed to get service %s/%s due to: %w", nameSpace.Namespace, nameSpace.Name, err)
 	}
-	return true, svc, nil
+	return svc, nil
 }
 
 // createService creates the service
 func (r *NodeObservabilityReconciler) createService(ctx context.Context, svc *corev1.Service) error {
 	if err := r.Create(ctx, svc); err != nil {
-		return fmt.Errorf("failed to create Service %s/%s: %w", svc.Namespace, svc.Name, err)
+		return fmt.Errorf("failed to create service %s/%s: %w", svc.Namespace, svc.Name, err)
 	}
-	r.Log.Info("created Service", "Service.Namespace", svc.Namespace, "Service.Name", svc.Name)
+	r.Log.Info("created service", "service.Namespace", svc.Namespace, "service.Name", svc.Name)
 	return nil
+}
+
+func (r *NodeObservabilityReconciler) updateService(ctx context.Context, current, desired *corev1.Service) (*corev1.Service, error) {
+	updatedService := current.DeepCopy()
+	var updated bool
+
+	if !cmp.Equal(current.ObjectMeta.OwnerReferences, desired.ObjectMeta.OwnerReferences) {
+		updatedService.ObjectMeta.OwnerReferences = desired.ObjectMeta.OwnerReferences
+		updated = true
+	}
+
+	if !portsMatch(updatedService.Spec.Ports, desired.Spec.Ports) {
+		updatedService.Spec.Ports = desired.Spec.Ports
+		updated = true
+	}
+	if !equality.Semantic.DeepEqual(updatedService.Spec.Selector, desired.Spec.Selector) {
+		updatedService.Spec.Selector = desired.Spec.Selector
+		updated = true
+	}
+
+	if updatedService.Spec.Type != desired.Spec.Type {
+		updatedService.Spec.Type = desired.Spec.Type
+		updated = true
+	}
+
+	if updatedService.Annotations == nil {
+		updatedService.Annotations = make(map[string]string)
+	}
+	for annotationKey, annotationValue := range desired.Annotations {
+		if currentAnnotationValue, ok := updatedService.Annotations[annotationKey]; !ok || currentAnnotationValue != annotationValue {
+			updatedService.Annotations[annotationKey] = annotationValue
+			updated = true
+		}
+	}
+
+	if updated {
+		return updatedService, r.Update(ctx, updatedService)
+	}
+	return updatedService, nil
 }
 
 // desiredService returns a service object
@@ -77,14 +126,6 @@ func (r *NodeObservabilityReconciler) desiredService(nodeObs *v1alpha1.NodeObser
 			Name:        serviceName,
 			Annotations: requestCerts,
 			Labels:      ls,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Name:       nodeObs.Name,
-					Kind:       nodeObs.Kind,
-					UID:        nodeObs.UID,
-					APIVersion: nodeObs.APIVersion,
-				},
-			},
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,
@@ -99,4 +140,39 @@ func (r *NodeObservabilityReconciler) desiredService(nodeObs *v1alpha1.NodeObser
 		},
 	}
 	return svc
+}
+
+type SortableServicePort []corev1.ServicePort
+
+func (s SortableServicePort) Len() int {
+	return len(s)
+}
+
+func (s SortableServicePort) Less(i, j int) bool {
+	return strings.Compare(s[i].Name, s[j].Name) < 0
+}
+
+func (s SortableServicePort) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func portsMatch(current, desired SortableServicePort) bool {
+	if len(current) != len(desired) {
+		return false
+	}
+	currentCopy := make(SortableServicePort, len(current))
+	copy(currentCopy, current)
+	sort.Sort(currentCopy)
+	desiredCopy := make(SortableServicePort, len(desired))
+	copy(desiredCopy, desired)
+	sort.Sort(desiredCopy)
+
+	for i := 0; i < len(currentCopy); i++ {
+		c := currentCopy[i]
+		d := desiredCopy[i]
+		if c.Name != d.Name || c.Port != d.Port || c.TargetPort.IntVal != d.TargetPort.IntVal {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/operator/controller/nodeobservability/service_test.go
+++ b/pkg/operator/controller/nodeobservability/service_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021.
+Copyright 2019.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,10 +20,15 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -31,38 +36,169 @@ import (
 	"github.com/openshift/node-observability-operator/pkg/operator/controller/test"
 )
 
-// TODO fix TestEnsureService
-func TestEnsureService(t *testing.T) {
-	nodeObs := &operatorv1alpha1.NodeObservability{}
-	makeService := func() *corev1.Service {
-		sa := corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      serviceName,
-				Namespace: nodeObs.Namespace,
+func testControllerService(name, namespace string, selector, annotations map[string]string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: corev1.ClusterIPNone,
+			Type:      corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Protocol:   corev1.ProtocolTCP,
+					Port:       port,
+					TargetPort: intstr.FromInt(targetPort),
+				},
 			},
-		}
-		return &sa
+			Selector: selector,
+		},
 	}
+}
+
+func TestEnsureService(t *testing.T) {
 	testCases := []struct {
 		name            string
 		existingObjects []runtime.Object
-		expectedExist   bool
-		expectedSA      *corev1.Service
-		errExpected     bool
+		deployment      *appsv1.Deployment
+		expectedService *corev1.Service
 	}{
 		{
-			name:            "Does not exist",
-			existingObjects: []runtime.Object{},
-			expectedExist:   true,
-			expectedSA:      makeService(),
+			name: "new service",
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "nodeobservability", "nodeobs_cr": "test"},
+					},
+				},
+			},
+			expectedService: testControllerService(
+				podName,
+				test.TestNamespace,
+				map[string]string{"app": "nodeobservability", "nodeobs_cr": "test"},
+				map[string]string{injectCertsKey: podName},
+			),
 		},
 		{
-			name: "Exists",
+			name: "existing service, selector modified",
 			existingObjects: []runtime.Object{
-				makeService(),
+				testControllerService(
+					podName,
+					test.TestNamespace,
+					map[string]string{"app": "nodeobservability-old", "nodeobs_cr": "test"},
+					map[string]string{injectCertsKey: podName},
+				),
 			},
-			expectedExist: true,
-			expectedSA:    makeService(),
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "nodeobservability", "nodeobs_cr": "test"},
+					},
+				},
+			},
+			expectedService: testControllerService(
+				podName,
+				test.TestNamespace,
+				map[string]string{"app": "nodeobservability", "nodeobs_cr": "test"},
+				map[string]string{injectCertsKey: podName},
+			),
+		},
+		{
+			name: "existing service, ports modified",
+			existingObjects: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-observability-agent", Namespace: "test-namespace"},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: corev1.ClusterIPNone,
+						Type:      corev1.ServiceTypeClusterIP,
+						Ports: []corev1.ServicePort{
+							{
+								Protocol:   corev1.ProtocolTCP,
+								Port:       9440,
+								TargetPort: intstr.FromInt(9440),
+							},
+						},
+						Selector: map[string]string{"app": "nodeobservability", "nodeobs_cr": "test"},
+					},
+				},
+			},
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "nodeobservability", "nodeobs_cr": "test"},
+					},
+				},
+			},
+			expectedService: testControllerService(
+				podName,
+				test.TestNamespace,
+				map[string]string{"app": "nodeobservability", "nodeobs_cr": "test"},
+				map[string]string{injectCertsKey: podName},
+			),
+		},
+		{
+			name: "existing service, service type modified",
+			existingObjects: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-observability-agent", Namespace: "test-namespace"},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: corev1.ClusterIPNone,
+						Type:      corev1.ServiceTypeNodePort,
+						Ports: []corev1.ServicePort{
+							{
+								Protocol:   corev1.ProtocolTCP,
+								Port:       port,
+								TargetPort: intstr.FromInt(targetPort),
+							},
+						},
+						Selector: map[string]string{"app": "nodeobservability", "nodeobs_cr": "test"},
+					},
+				},
+			},
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "controller"},
+					},
+				},
+			},
+			expectedService: testControllerService(
+				podName,
+				test.TestNamespace,
+				map[string]string{"app": "nodeobservability", "nodeobs_cr": "test"},
+				map[string]string{injectCertsKey: podName},
+			),
+		},
+		{
+			name: "existing service, extra annotations present",
+			existingObjects: []runtime.Object{
+				testControllerService(
+					podName,
+					test.TestNamespace,
+					map[string]string{"app": "nodeobservability", "nodeobs_cr": "test"},
+					map[string]string{
+						"extra-annotation-key": "extra-annotation-value",
+					},
+				),
+			},
+			deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "controller"},
+					},
+				},
+			},
+			expectedService: testControllerService(
+				podName,
+				test.TestNamespace,
+				map[string]string{"app": "nodeobservability", "nodeobs_cr": "test"},
+				map[string]string{
+					injectCertsKey:         podName,
+					"extra-annotation-key": "extra-annotation-value",
+				},
+			),
 		},
 	}
 
@@ -70,21 +206,34 @@ func TestEnsureService(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cl := fake.NewClientBuilder().WithRuntimeObjects(tc.existingObjects...).Build()
 			r := &NodeObservabilityReconciler{
-				Client: cl,
-				Scheme: test.Scheme,
-				Log:    zap.New(zap.UseDevMode(true)),
+				Client:    cl,
+				Scheme:    test.Scheme,
+				Namespace: test.TestNamespace,
+				Log:       zap.New(zap.UseDevMode(true)),
 			}
-			nodeObs := &operatorv1alpha1.NodeObservability{}
+			nodeObs := &operatorv1alpha1.NodeObservability{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			}
 
 			_, err := r.ensureService(context.TODO(), nodeObs, test.TestNamespace)
 			if err != nil {
-				if !tc.errExpected {
-					t.Fatalf("unexpected error received: %v", err)
-				}
+				t.Fatalf("unexpected error received: %v", err)
+			}
+			var s corev1.Service
+			err = r.Client.Get(context.Background(), types.NamespacedName{Name: tc.expectedService.Name, Namespace: tc.expectedService.Namespace}, &s)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
 				return
 			}
-			if tc.errExpected {
-				t.Fatalf("Error expected but wasn't received")
+
+			if diff := cmp.Diff(tc.expectedService.Annotations, s.Annotations); diff != "" {
+				t.Errorf("unexpected annotations\n%s", diff)
+			}
+
+			if !equality.Semantic.DeepEqual(s.Spec, tc.expectedService.Spec) {
+				t.Errorf("service has unexpected configuration:\n%s", cmp.Diff(s.Spec, tc.expectedService.Spec))
 			}
 		})
 	}

--- a/pkg/operator/controller/nodeobservability/service_test.go
+++ b/pkg/operator/controller/nodeobservability/service_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019.
+Copyright 2022.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -172,7 +172,7 @@ func TestEnsureService(t *testing.T) {
 			),
 		},
 		{
-			name: "existing service, extra annotations present",
+			name: "existing service, extra annotations present are allowed during updates",
 			existingObjects: []runtime.Object{
 				testControllerService(
 					podName,

--- a/pkg/operator/controller/nodeobservability/service_test.go
+++ b/pkg/operator/controller/nodeobservability/service_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/node-observability-operator/pkg/operator/controller/test"
 )
 
+// TODO fix TestEnsureService
 func TestEnsureService(t *testing.T) {
 	nodeObs := &operatorv1alpha1.NodeObservability{}
 	makeService := func() *corev1.Service {
@@ -75,7 +76,7 @@ func TestEnsureService(t *testing.T) {
 			}
 			nodeObs := &operatorv1alpha1.NodeObservability{}
 
-			gotExist, _, err := r.ensureService(context.TODO(), nodeObs, test.TestNamespace)
+			_, err := r.ensureService(context.TODO(), nodeObs, test.TestNamespace)
 			if err != nil {
 				if !tc.errExpected {
 					t.Fatalf("unexpected error received: %v", err)
@@ -84,9 +85,6 @@ func TestEnsureService(t *testing.T) {
 			}
 			if tc.errExpected {
 				t.Fatalf("Error expected but wasn't received")
-			}
-			if gotExist != tc.expectedExist {
-				t.Errorf("expected service's exist to be %t, got %t", tc.expectedExist, gotExist)
 			}
 		})
 	}

--- a/pkg/operator/controller/nodeobservability/serviceaccount.go
+++ b/pkg/operator/controller/nodeobservability/serviceaccount.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1alpha1 "github.com/openshift/node-observability-operator/api/v1alpha1"
 )
@@ -39,7 +38,7 @@ func (r *NodeObservabilityReconciler) ensureServiceAccount(ctx context.Context, 
 		if err := r.createServiceAccount(ctx, desired); err != nil {
 			return nil, err
 		}
-		log.FromContext(ctx).Info("successfully created serviceaccount", "name", nameSpace.Name, "namespace", nameSpace.Namespace)
+		r.Log.V(1).Info("successfully created serviceaccount", "sa.name", nameSpace.Name, "sa.namespace", nameSpace.Namespace)
 		return r.currentServiceAccount(ctx, nameSpace)
 	}
 
@@ -60,7 +59,7 @@ func (r *NodeObservabilityReconciler) createServiceAccount(ctx context.Context, 
 	if err := r.Create(ctx, sa); err != nil {
 		return fmt.Errorf("failed to create serviceaccount %s/%s: %w", sa.Namespace, sa.Name, err)
 	}
-	r.Log.Info("created serviceaccount", "serviceaccount.Namespace", sa.Namespace, "serviceaccount.Name", sa.Name)
+	r.Log.Info("created serviceaccount", "sa.Namespace", sa.Namespace, "sa.Name", sa.Name)
 	return nil
 }
 

--- a/pkg/operator/controller/nodeobservability/serviceaccount_test.go
+++ b/pkg/operator/controller/nodeobservability/serviceaccount_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/node-observability-operator/pkg/operator/controller/test"
 )
 
+// TODO fix TestEnsureServiceAccount
 func TestEnsureServiceAccount(t *testing.T) {
 	nodeObs := &operatorv1alpha1.NodeObservability{}
 	makeServiceAccount := func() *corev1.ServiceAccount {
@@ -75,7 +76,7 @@ func TestEnsureServiceAccount(t *testing.T) {
 			}
 			nodeObs := &operatorv1alpha1.NodeObservability{}
 
-			gotExist, _, err := r.ensureServiceAccount(context.TODO(), nodeObs, test.TestNamespace)
+			_, err := r.ensureServiceAccount(context.TODO(), nodeObs, test.TestNamespace)
 			if err != nil {
 				if !tc.errExpected {
 					t.Fatalf("unexpected error received: %v", err)
@@ -84,9 +85,6 @@ func TestEnsureServiceAccount(t *testing.T) {
 			}
 			if tc.errExpected {
 				t.Fatalf("Error expected but wasn't received")
-			}
-			if gotExist != tc.expectedExist {
-				t.Errorf("expected service account's exist to be %t, got %t", tc.expectedExist, gotExist)
 			}
 		})
 	}

--- a/pkg/operator/controller/nodeobservability/simulate-error-schema.go
+++ b/pkg/operator/controller/nodeobservability/simulate-error-schema.go
@@ -1,12 +1,9 @@
 package nodeobservabilitycontroller
 
 const (
-	saObj  = "serviceaccount"
-	svcObj = "service"
 	sccObj = "securitycontextconstraint"
 	crObj  = "clusterrole"
 	crbObj = "clusterrolebinding"
-	dsObj  = "daemonset"
 )
 
 // ErrTestObject - simple struct used to inject errors for testing

--- a/pkg/operator/controller/nodeobservabilityrun/controller.go
+++ b/pkg/operator/controller/nodeobservabilityrun/controller.go
@@ -76,7 +76,8 @@ func (r *NodeObservabilityRunReconciler) Reconcile(ctx context.Context, req ctrl
 	if ctxLog, err := logr.FromContext(ctx); err == nil {
 		r.Log = ctxLog
 	}
-	r.Log.V(1).Info("reconciling", "request", req)
+
+	r.Log.V(1).Info("reconciliation started")
 
 	instance := &nodeobservabilityv1alpha1.NodeObservabilityRun{}
 	err = r.Get(ctx, req.NamespacedName, instance)

--- a/test/e2e/nodeobservability_test.go
+++ b/test/e2e/nodeobservability_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Node Observability Operator end-to-end test suite", Ordered, f
 				Eventually(func() bool {
 					Expect(k8sClient.Get(ctx, runNamespacedName, run)).To(Succeed())
 					return run.Status.FinishedTimestamp.IsZero()
-				}, 600, time.Second).Should(BeFalse())
+				}, 900, time.Second).Should(BeFalse())
 				Expect(run.Status.FailedAgents).To(BeEmpty())
 			})
 		})

--- a/test/e2e/nodeobservability_test.go
+++ b/test/e2e/nodeobservability_test.go
@@ -22,7 +22,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/openshift/node-observability-operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	operatorv1alpha1 "github.com/openshift/node-observability-operator/api/v1alpha1"
 )
 
@@ -37,28 +38,18 @@ var _ = Describe("Node Observability Operator end-to-end test suite", Ordered, f
 
 	BeforeAll(func() {
 		nodeobservability = testNodeObservability()
-		By("deploying Node Observability Agents",
-			func() {
-				Expect(k8sClient.Create(ctx, nodeobservability)).To(Succeed(), "test NodeObservability resource created")
-
-				Eventually(
-					func() bool {
-						ds := &appsv1.DaemonSet{}
-						dsNamespacedName := types.NamespacedName{
-							Name:      "node-observability-ds",
-							Namespace: testNamespace,
-						}
-
-						nobs := &v1alpha1.NodeObservability{}
-						nobsName := types.NamespacedName{Name: "cluster"}
-
-						Expect(k8sClient.Get(ctx, dsNamespacedName, ds)).To(Succeed())
-
-						Expect(k8sClient.Get(ctx, nobsName, nobs)).To(Succeed())
-						return ds.Status.NumberReady != 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady && nobs.Status.IsReady()
-					}, "10m").Should(BeTrue(), "number of ready agents != number of desired agents and nodeobservabilitymachineconfig and nodeobservability should be in ready state")
-			})
-
+		By("deploying Node Observability Agents", func() {
+			Expect(k8sClient.Create(ctx, nodeobservability)).To(Succeed(), "test NodeObservability resource created")
+			Eventually(func() bool {
+				ds := &appsv1.DaemonSet{}
+				dsNamespacedName := types.NamespacedName{
+					Name:      "node-observability-ds",
+					Namespace: testNamespace,
+				}
+				Expect(client.IgnoreNotFound(k8sClient.Get(ctx, dsNamespacedName, ds))).To(Succeed())
+				return ds.Status.NumberReady != 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady
+			}, 60, time.Second).Should(BeTrue(), "number of ready agents != number of desired agents")
+		})
 	})
 	Context("Happy Path scenario - single scrape is initiated and it is expected to succeed", func() {
 		var (

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
@@ -1,0 +1,155 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package cmpopts provides common options for the cmp package.
+package cmpopts
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func equateAlways(_, _ interface{}) bool { return true }
+
+// EquateEmpty returns a Comparer option that determines all maps and slices
+// with a length of zero to be equal, regardless of whether they are nil.
+//
+// EquateEmpty can be used in conjunction with SortSlices and SortMaps.
+func EquateEmpty() cmp.Option {
+	return cmp.FilterValues(isEmpty, cmp.Comparer(equateAlways))
+}
+
+func isEmpty(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Slice || vx.Kind() == reflect.Map) &&
+		(vx.Len() == 0 && vy.Len() == 0)
+}
+
+// EquateApprox returns a Comparer option that determines float32 or float64
+// values to be equal if they are within a relative fraction or absolute margin.
+// This option is not used when either x or y is NaN or infinite.
+//
+// The fraction determines that the difference of two values must be within the
+// smaller fraction of the two values, while the margin determines that the two
+// values must be within some absolute margin.
+// To express only a fraction or only a margin, use 0 for the other parameter.
+// The fraction and margin must be non-negative.
+//
+// The mathematical expression used is equivalent to:
+//	|x-y| ≤ max(fraction*min(|x|, |y|), margin)
+//
+// EquateApprox can be used in conjunction with EquateNaNs.
+func EquateApprox(fraction, margin float64) cmp.Option {
+	if margin < 0 || fraction < 0 || math.IsNaN(margin) || math.IsNaN(fraction) {
+		panic("margin or fraction must be a non-negative number")
+	}
+	a := approximator{fraction, margin}
+	return cmp.Options{
+		cmp.FilterValues(areRealF64s, cmp.Comparer(a.compareF64)),
+		cmp.FilterValues(areRealF32s, cmp.Comparer(a.compareF32)),
+	}
+}
+
+type approximator struct{ frac, marg float64 }
+
+func areRealF64s(x, y float64) bool {
+	return !math.IsNaN(x) && !math.IsNaN(y) && !math.IsInf(x, 0) && !math.IsInf(y, 0)
+}
+func areRealF32s(x, y float32) bool {
+	return areRealF64s(float64(x), float64(y))
+}
+func (a approximator) compareF64(x, y float64) bool {
+	relMarg := a.frac * math.Min(math.Abs(x), math.Abs(y))
+	return math.Abs(x-y) <= math.Max(a.marg, relMarg)
+}
+func (a approximator) compareF32(x, y float32) bool {
+	return a.compareF64(float64(x), float64(y))
+}
+
+// EquateNaNs returns a Comparer option that determines float32 and float64
+// NaN values to be equal.
+//
+// EquateNaNs can be used in conjunction with EquateApprox.
+func EquateNaNs() cmp.Option {
+	return cmp.Options{
+		cmp.FilterValues(areNaNsF64s, cmp.Comparer(equateAlways)),
+		cmp.FilterValues(areNaNsF32s, cmp.Comparer(equateAlways)),
+	}
+}
+
+func areNaNsF64s(x, y float64) bool {
+	return math.IsNaN(x) && math.IsNaN(y)
+}
+func areNaNsF32s(x, y float32) bool {
+	return areNaNsF64s(float64(x), float64(y))
+}
+
+// EquateApproxTime returns a Comparer option that determines two non-zero
+// time.Time values to be equal if they are within some margin of one another.
+// If both times have a monotonic clock reading, then the monotonic time
+// difference will be used. The margin must be non-negative.
+func EquateApproxTime(margin time.Duration) cmp.Option {
+	if margin < 0 {
+		panic("margin must be a non-negative number")
+	}
+	a := timeApproximator{margin}
+	return cmp.FilterValues(areNonZeroTimes, cmp.Comparer(a.compare))
+}
+
+func areNonZeroTimes(x, y time.Time) bool {
+	return !x.IsZero() && !y.IsZero()
+}
+
+type timeApproximator struct {
+	margin time.Duration
+}
+
+func (a timeApproximator) compare(x, y time.Time) bool {
+	// Avoid subtracting times to avoid overflow when the
+	// difference is larger than the largest representable duration.
+	if x.After(y) {
+		// Ensure x is always before y
+		x, y = y, x
+	}
+	// We're within the margin if x+margin >= y.
+	// Note: time.Time doesn't have AfterOrEqual method hence the negation.
+	return !x.Add(a.margin).Before(y)
+}
+
+// AnyError is an error that matches any non-nil error.
+var AnyError anyError
+
+type anyError struct{}
+
+func (anyError) Error() string     { return "any error" }
+func (anyError) Is(err error) bool { return err != nil }
+
+// EquateErrors returns a Comparer option that determines errors to be equal
+// if errors.Is reports them to match. The AnyError error can be used to
+// match any non-nil error.
+func EquateErrors() cmp.Option {
+	return cmp.FilterValues(areConcreteErrors, cmp.Comparer(compareErrors))
+}
+
+// areConcreteErrors reports whether x and y are types that implement error.
+// The input types are deliberately of the interface{} type rather than the
+// error type so that we can handle situations where the current type is an
+// interface{}, but the underlying concrete types both happen to implement
+// the error interface.
+func areConcreteErrors(x, y interface{}) bool {
+	_, ok1 := x.(error)
+	_, ok2 := y.(error)
+	return ok1 && ok2
+}
+
+func compareErrors(x, y interface{}) bool {
+	xe := x.(error)
+	ye := y.(error)
+	return errors.Is(xe, ye) || errors.Is(ye, xe)
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
@@ -1,0 +1,206 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// IgnoreFields returns an Option that ignores fields of the
+// given names on a single struct type. It respects the names of exported fields
+// that are forwarded due to struct embedding.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to ignore a
+// specific sub-field that is embedded or nested within the parent struct.
+func IgnoreFields(typ interface{}, names ...string) cmp.Option {
+	sf := newStructFilter(typ, names...)
+	return cmp.FilterPath(sf.filter, cmp.Ignore())
+}
+
+// IgnoreTypes returns an Option that ignores all values assignable to
+// certain types, which are specified by passing in a value of each type.
+func IgnoreTypes(typs ...interface{}) cmp.Option {
+	tf := newTypeFilter(typs...)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type typeFilter []reflect.Type
+
+func newTypeFilter(typs ...interface{}) (tf typeFilter) {
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil {
+			// This occurs if someone tries to pass in sync.Locker(nil)
+			panic("cannot determine type; consider using IgnoreInterfaces")
+		}
+		tf = append(tf, t)
+	}
+	return tf
+}
+func (tf typeFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreInterfaces returns an Option that ignores all values or references of
+// values assignable to certain interface types. These interfaces are specified
+// by passing in an anonymous struct with the interface types embedded in it.
+// For example, to ignore sync.Locker, pass in struct{sync.Locker}{}.
+func IgnoreInterfaces(ifaces interface{}) cmp.Option {
+	tf := newIfaceFilter(ifaces)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type ifaceFilter []reflect.Type
+
+func newIfaceFilter(ifaces interface{}) (tf ifaceFilter) {
+	t := reflect.TypeOf(ifaces)
+	if ifaces == nil || t.Name() != "" || t.Kind() != reflect.Struct {
+		panic("input must be an anonymous struct")
+	}
+	for i := 0; i < t.NumField(); i++ {
+		fi := t.Field(i)
+		switch {
+		case !fi.Anonymous:
+			panic("struct cannot have named fields")
+		case fi.Type.Kind() != reflect.Interface:
+			panic("embedded field must be an interface type")
+		case fi.Type.NumMethod() == 0:
+			// This matches everything; why would you ever want this?
+			panic("cannot ignore empty interface")
+		default:
+			tf = append(tf, fi.Type)
+		}
+	}
+	return tf
+}
+func (tf ifaceFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+		if t.Kind() != reflect.Ptr && reflect.PtrTo(t).AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreUnexported returns an Option that only ignores the immediate unexported
+// fields of a struct, including anonymous fields of unexported types.
+// In particular, unexported fields within the struct's exported fields
+// of struct types, including anonymous fields, will not be ignored unless the
+// type of the field itself is also passed to IgnoreUnexported.
+//
+// Avoid ignoring unexported fields of a type which you do not control (i.e. a
+// type from another repository), as changes to the implementation of such types
+// may change how the comparison behaves. Prefer a custom Comparer instead.
+func IgnoreUnexported(typs ...interface{}) cmp.Option {
+	ux := newUnexportedFilter(typs...)
+	return cmp.FilterPath(ux.filter, cmp.Ignore())
+}
+
+type unexportedFilter struct{ m map[reflect.Type]bool }
+
+func newUnexportedFilter(typs ...interface{}) unexportedFilter {
+	ux := unexportedFilter{m: make(map[reflect.Type]bool)}
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil || t.Kind() != reflect.Struct {
+			panic(fmt.Sprintf("%T must be a non-pointer struct", typ))
+		}
+		ux.m[t] = true
+	}
+	return ux
+}
+func (xf unexportedFilter) filter(p cmp.Path) bool {
+	sf, ok := p.Index(-1).(cmp.StructField)
+	if !ok {
+		return false
+	}
+	return xf.m[p.Index(-2).Type()] && !isExported(sf.Name())
+}
+
+// isExported reports whether the identifier is exported.
+func isExported(id string) bool {
+	r, _ := utf8.DecodeRuneInString(id)
+	return unicode.IsUpper(r)
+}
+
+// IgnoreSliceElements returns an Option that ignores elements of []V.
+// The discard function must be of the form "func(T) bool" which is used to
+// ignore slice elements of type V, where V is assignable to T.
+// Elements are ignored if the function reports true.
+func IgnoreSliceElements(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.ValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		si, ok := p.Index(-1).(cmp.SliceIndex)
+		if !ok {
+			return false
+		}
+		if !si.Type().AssignableTo(vf.Type().In(0)) {
+			return false
+		}
+		vx, vy := si.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}
+
+// IgnoreMapEntries returns an Option that ignores entries of map[K]V.
+// The discard function must be of the form "func(T, R) bool" which is used to
+// ignore map entries of type K and V, where K and V are assignable to T and R.
+// Entries are ignored if the function reports true.
+func IgnoreMapEntries(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.KeyValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		mi, ok := p.Index(-1).(cmp.MapIndex)
+		if !ok {
+			return false
+		}
+		if !mi.Key().Type().AssignableTo(vf.Type().In(0)) || !mi.Type().AssignableTo(vf.Type().In(1)) {
+			return false
+		}
+		k := mi.Key()
+		vx, vy := mi.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{k, vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{k, vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
@@ -1,0 +1,147 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// SortSlices returns a Transformer option that sorts all []V.
+// The less function must be of the form "func(T, T) bool" which is used to
+// sort any slice with element type V that is assignable to T.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//
+// The less function does not have to be "total". That is, if !less(x, y) and
+// !less(y, x) for two elements x and y, their relative order is maintained.
+//
+// SortSlices can be used in conjunction with EquateEmpty.
+func SortSlices(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
+	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
+	}
+	ss := sliceSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ss.filter, cmp.Transformer("cmpopts.SortSlices", ss.sort))
+}
+
+type sliceSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ss sliceSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	if !(x != nil && y != nil && vx.Type() == vy.Type()) ||
+		!(vx.Kind() == reflect.Slice && vx.Type().Elem().AssignableTo(ss.in)) ||
+		(vx.Len() <= 1 && vy.Len() <= 1) {
+		return false
+	}
+	// Check whether the slices are already sorted to avoid an infinite
+	// recursion cycle applying the same transform to itself.
+	ok1 := sort.SliceIsSorted(x, func(i, j int) bool { return ss.less(vx, i, j) })
+	ok2 := sort.SliceIsSorted(y, func(i, j int) bool { return ss.less(vy, i, j) })
+	return !ok1 || !ok2
+}
+func (ss sliceSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	dst := reflect.MakeSlice(src.Type(), src.Len(), src.Len())
+	for i := 0; i < src.Len(); i++ {
+		dst.Index(i).Set(src.Index(i))
+	}
+	sort.SliceStable(dst.Interface(), func(i, j int) bool { return ss.less(dst, i, j) })
+	ss.checkSort(dst)
+	return dst.Interface()
+}
+func (ss sliceSorter) checkSort(v reflect.Value) {
+	start := -1 // Start of a sequence of equal elements.
+	for i := 1; i < v.Len(); i++ {
+		if ss.less(v, i-1, i) {
+			// Check that first and last elements in v[start:i] are equal.
+			if start >= 0 && (ss.less(v, start, i-1) || ss.less(v, i-1, start)) {
+				panic(fmt.Sprintf("incomparable values detected: want equal elements: %v", v.Slice(start, i)))
+			}
+			start = -1
+		} else if start == -1 {
+			start = i
+		}
+	}
+}
+func (ss sliceSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i), v.Index(j)
+	return ss.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}
+
+// SortMaps returns a Transformer option that flattens map[K]V types to be a
+// sorted []struct{K, V}. The less function must be of the form
+// "func(T, T) bool" which is used to sort any map with key K that is
+// assignable to T.
+//
+// Flattening the map into a slice has the property that cmp.Equal is able to
+// use Comparers on K or the K.Equal method if it exists.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//	• Total: if x != y, then either less(x, y) or less(y, x)
+//
+// SortMaps can be used in conjunction with EquateEmpty.
+func SortMaps(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
+	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
+	}
+	ms := mapSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ms.filter, cmp.Transformer("cmpopts.SortMaps", ms.sort))
+}
+
+type mapSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ms mapSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Map && vx.Type().Key().AssignableTo(ms.in)) &&
+		(vx.Len() != 0 || vy.Len() != 0)
+}
+func (ms mapSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	outType := reflect.StructOf([]reflect.StructField{
+		{Name: "K", Type: src.Type().Key()},
+		{Name: "V", Type: src.Type().Elem()},
+	})
+	dst := reflect.MakeSlice(reflect.SliceOf(outType), src.Len(), src.Len())
+	for i, k := range src.MapKeys() {
+		v := reflect.New(outType).Elem()
+		v.Field(0).Set(k)
+		v.Field(1).Set(src.MapIndex(k))
+		dst.Index(i).Set(v)
+	}
+	sort.Slice(dst.Interface(), func(i, j int) bool { return ms.less(dst, i, j) })
+	ms.checkSort(dst)
+	return dst.Interface()
+}
+func (ms mapSorter) checkSort(v reflect.Value) {
+	for i := 1; i < v.Len(); i++ {
+		if !ms.less(v, i-1, i) {
+			panic(fmt.Sprintf("partial order detected: want %v < %v", v.Index(i-1), v.Index(i)))
+		}
+	}
+}
+func (ms mapSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i).Field(0), v.Index(j).Field(0)
+	return ms.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
@@ -1,0 +1,187 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// filterField returns a new Option where opt is only evaluated on paths that
+// include a specific exported field on a single struct type.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to select a
+// specific sub-field that is embedded or nested within the parent struct.
+func filterField(typ interface{}, name string, opt cmp.Option) cmp.Option {
+	// TODO: This is currently unexported over concerns of how helper filters
+	// can be composed together easily.
+	// TODO: Add tests for FilterField.
+
+	sf := newStructFilter(typ, name)
+	return cmp.FilterPath(sf.filter, opt)
+}
+
+type structFilter struct {
+	t  reflect.Type // The root struct type to match on
+	ft fieldTree    // Tree of fields to match on
+}
+
+func newStructFilter(typ interface{}, names ...string) structFilter {
+	// TODO: Perhaps allow * as a special identifier to allow ignoring any
+	// number of path steps until the next field match?
+	// This could be useful when a concrete struct gets transformed into
+	// an anonymous struct where it is not possible to specify that by type,
+	// but the transformer happens to provide guarantees about the names of
+	// the transformed fields.
+
+	t := reflect.TypeOf(typ)
+	if t == nil || t.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("%T must be a non-pointer struct", typ))
+	}
+	var ft fieldTree
+	for _, name := range names {
+		cname, err := canonicalName(t, name)
+		if err != nil {
+			panic(fmt.Sprintf("%s: %v", strings.Join(cname, "."), err))
+		}
+		ft.insert(cname)
+	}
+	return structFilter{t, ft}
+}
+
+func (sf structFilter) filter(p cmp.Path) bool {
+	for i, ps := range p {
+		if ps.Type().AssignableTo(sf.t) && sf.ft.matchPrefix(p[i+1:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// fieldTree represents a set of dot-separated identifiers.
+//
+// For example, inserting the following selectors:
+//	Foo
+//	Foo.Bar.Baz
+//	Foo.Buzz
+//	Nuka.Cola.Quantum
+//
+// Results in a tree of the form:
+//	{sub: {
+//		"Foo": {ok: true, sub: {
+//			"Bar": {sub: {
+//				"Baz": {ok: true},
+//			}},
+//			"Buzz": {ok: true},
+//		}},
+//		"Nuka": {sub: {
+//			"Cola": {sub: {
+//				"Quantum": {ok: true},
+//			}},
+//		}},
+//	}}
+type fieldTree struct {
+	ok  bool                 // Whether this is a specified node
+	sub map[string]fieldTree // The sub-tree of fields under this node
+}
+
+// insert inserts a sequence of field accesses into the tree.
+func (ft *fieldTree) insert(cname []string) {
+	if ft.sub == nil {
+		ft.sub = make(map[string]fieldTree)
+	}
+	if len(cname) == 0 {
+		ft.ok = true
+		return
+	}
+	sub := ft.sub[cname[0]]
+	sub.insert(cname[1:])
+	ft.sub[cname[0]] = sub
+}
+
+// matchPrefix reports whether any selector in the fieldTree matches
+// the start of path p.
+func (ft fieldTree) matchPrefix(p cmp.Path) bool {
+	for _, ps := range p {
+		switch ps := ps.(type) {
+		case cmp.StructField:
+			ft = ft.sub[ps.Name()]
+			if ft.ok {
+				return true
+			}
+			if len(ft.sub) == 0 {
+				return false
+			}
+		case cmp.Indirect:
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// canonicalName returns a list of identifiers where any struct field access
+// through an embedded field is expanded to include the names of the embedded
+// types themselves.
+//
+// For example, suppose field "Foo" is not directly in the parent struct,
+// but actually from an embedded struct of type "Bar". Then, the canonical name
+// of "Foo" is actually "Bar.Foo".
+//
+// Suppose field "Foo" is not directly in the parent struct, but actually
+// a field in two different embedded structs of types "Bar" and "Baz".
+// Then the selector "Foo" causes a panic since it is ambiguous which one it
+// refers to. The user must specify either "Bar.Foo" or "Baz.Foo".
+func canonicalName(t reflect.Type, sel string) ([]string, error) {
+	var name string
+	sel = strings.TrimPrefix(sel, ".")
+	if sel == "" {
+		return nil, fmt.Errorf("name must not be empty")
+	}
+	if i := strings.IndexByte(sel, '.'); i < 0 {
+		name, sel = sel, ""
+	} else {
+		name, sel = sel[:i], sel[i:]
+	}
+
+	// Type must be a struct or pointer to struct.
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%v must be a struct", t)
+	}
+
+	// Find the canonical name for this current field name.
+	// If the field exists in an embedded struct, then it will be expanded.
+	sf, _ := t.FieldByName(name)
+	if !isExported(name) {
+		// Avoid using reflect.Type.FieldByName for unexported fields due to
+		// buggy behavior with regard to embeddeding and unexported fields.
+		// See https://golang.org/issue/4876 for details.
+		sf = reflect.StructField{}
+		for i := 0; i < t.NumField() && sf.Name == ""; i++ {
+			if t.Field(i).Name == name {
+				sf = t.Field(i)
+			}
+		}
+	}
+	if sf.Name == "" {
+		return []string{name}, fmt.Errorf("does not exist")
+	}
+	var ss []string
+	for i := range sf.Index {
+		ss = append(ss, t.FieldByIndex(sf.Index[:i+1]).Name)
+	}
+	if sel == "" {
+		return ss, nil
+	}
+	ssPost, err := canonicalName(sf.Type, sel)
+	return append(ss, ssPost...), err
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
@@ -1,0 +1,35 @@
+// Copyright 2018, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"github.com/google/go-cmp/cmp"
+)
+
+type xformFilter struct{ xform cmp.Option }
+
+func (xf xformFilter) filter(p cmp.Path) bool {
+	for _, ps := range p {
+		if t, ok := ps.(cmp.Transform); ok && t.Option() == xf.xform {
+			return false
+		}
+	}
+	return true
+}
+
+// AcyclicTransformer returns a Transformer with a filter applied that ensures
+// that the transformer cannot be recursively applied upon its own output.
+//
+// An example use case is a transformer that splits a string by lines:
+//	AcyclicTransformer("SplitLines", func(s string) []string{
+//		return strings.Split(s, "\n")
+//	})
+//
+// Had this been an unfiltered Transformer instead, this would result in an
+// infinite cycle converting a string to []string to [][]string and so on.
+func AcyclicTransformer(name string, xformFunc interface{}) cmp.Option {
+	xf := xformFilter{cmp.Transformer(name, xformFunc)}
+	return cmp.FilterPath(xf.filter, xf.xform)
+}

--- a/vendor/github.com/google/go-cmp/cmp/compare.go
+++ b/vendor/github.com/google/go-cmp/cmp/compare.go
@@ -40,6 +40,8 @@ import (
 	"github.com/google/go-cmp/cmp/internal/value"
 )
 
+// TODO(≥go1.18): Use any instead of interface{}.
+
 // Equal reports whether x and y are equal by recursively applying the
 // following rules in the given order to x and y and all of their sub-values:
 //

--- a/vendor/github.com/google/go-cmp/cmp/report_compare.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_compare.go
@@ -116,7 +116,10 @@ func (opts formatOptions) FormatDiff(v *valueNode, ptrs *pointerReferences) (out
 	}
 
 	// For leaf nodes, format the value based on the reflect.Values alone.
-	if v.MaxDepth == 0 {
+	// As a special case, treat equal []byte as a leaf nodes.
+	isBytes := v.Type.Kind() == reflect.Slice && v.Type.Elem() == reflect.TypeOf(byte(0))
+	isEqualBytes := isBytes && v.NumDiff+v.NumIgnored+v.NumTransformed == 0
+	if v.MaxDepth == 0 || isEqualBytes {
 		switch opts.DiffMode {
 		case diffUnknown, diffIdentical:
 			// Format Equal.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -265,9 +265,10 @@ github.com/golangci/revgrep
 # github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4
 ## explicit
 github.com/golangci/unconvert
-# github.com/google/go-cmp v0.5.7
-## explicit; go 1.11
+# github.com/google/go-cmp v0.5.8
+## explicit; go 1.13
 github.com/google/go-cmp/cmp
+github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function


### PR DESCRIPTION
Description
===
Refactor reconcile loop logic to enforce required fields/schema of `DaemonSet`, `Service`, `ServiceAccount` and `NodeObservabilityMachineConfig` objects created by the operator. Simplifies error handling within the reconcile loop. 

## Changes
- `Dockerfile` - `podman` on v4.2 has short name aliasing is on by default and needs full image name to be present.
- `bundle/manifest` & `config/rbac/role.yaml` - Add `update` and `patch` RBAC verbs to enforced resources.
- `cmd/node-observability-operator/main.go` - Update kube-client to use non-cached client.
- `pkg/operator/controller/nodeobservability/simulate-error-schema.go` - Remove enforced objects from list, eventually need to remove `ErrTestObject` as well.
- `pkg/operator/controller/nodeobservability/controller_test.go` - Remove and fix tests logic after deleting usages of `ErrTestObject`.
- Enforces required fields of `DaemonSet`, `Service`, `ServiceAccount` and `NodeObservabilityMachineConfig` and adds additional tests.


Signed-off-by: Thejas N <thn@redhat.com>