### PR TITLE
api: v1alpha2 version added. part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,8 @@ test-e2e:
 	-v \
 	-tags e2e \
 	-run "$(TEST)" \
-	./test/e2e
+	./test/e2e \
+	-args --ginkgo.vv
 	
 verify: lint
 	hack/verify-bundle.sh

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ You can install the NodeObservability Operator by building and pushing the Opera
     ```sh
     oc set env deployment/node-observability-operator --containers=manager RELATED_IMAGE_AGENT=${MY_IMAGE_AGENT} -n node-observability-operator
     ```
+3. The previous step deploys the conversion webhook, which requires the TLS verification on the webhook server's side. The
+   manifests deployed through the `make deploy` command do not contain a valid certificate and key. You must provision a valid certificate and key through other tools.     
+   If you run on OpenShift, you can use a convenience script, `hack/add-serving-cert.sh` to enable [the service serving certificate feature](https://docs.openshift.com/container-platform/4.11/security/certificates/service-serving-certificate.html).    
+   Run the `hack/add-serving-cert.sh` script with the following inputs:
+   ```sh
+   hack/add-serving-cert.sh --crd "nodeobservabilities.nodeobservability.olm.openshift.io nodeobservabilitymachineconfigs.nodeobservability.olm.openshift.io" \
+   --service node-observability-operator-webhook-service --secret webhook-server-cert --namespace node-observability-operator
+   ```
+   *Note*: you may need to wait for the retry of the volume mount in the operator's POD
 
 ### Installing the `NodeObservability` Operator using a custom index image on the OperatorHub
 **Note**: It is recommended to use `podman` as a container engine.

--- a/api/v1alpha1/nodeobservability_conversion.go
+++ b/api/v1alpha1/nodeobservability_conversion.go
@@ -26,7 +26,7 @@ var nobWebhookLog = logf.Log.WithName("nob-conversion-webhook")
 
 // ConvertTo converts this NodeObservability to the Hub version (v1alpha2).
 func (src *NodeObservability) ConvertTo(dstRaw conversion.Hub) error {
-	nobWebhookLog.Info("Converting to v1alpha2", "name", src.Name)
+	nobWebhookLog.V(1).Info("converting to v1alpha2", "name", src.Name)
 
 	dst := dstRaw.(*v1alpha2.NodeObservability)
 
@@ -50,7 +50,7 @@ func (src *NodeObservability) ConvertTo(dstRaw conversion.Hub) error {
 func (dst *NodeObservability) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha2.NodeObservability)
 
-	nobWebhookLog.Info("Converting to v1alpha1", "name", src.Name)
+	nobWebhookLog.V(1).Info("converting to v1alpha1", "name", src.Name)
 
 	dst.Spec.Labels = src.Spec.NodeSelector
 

--- a/api/v1alpha1/nodeobservabilitymachineconfig_conversion.go
+++ b/api/v1alpha1/nodeobservabilitymachineconfig_conversion.go
@@ -26,7 +26,7 @@ var webhookNobmcLog = logf.Log.WithName("nobmc-conversion-webhook")
 
 // ConvertTo converts this NodeObservabilityMachineConfig to the Hub version (v1alpha2).
 func (src *NodeObservabilityMachineConfig) ConvertTo(dstRaw conversion.Hub) error {
-	webhookNobmcLog.Info("Converting to v1alpha2", "name", src.Name)
+	webhookNobmcLog.V(1).Info("converting to v1alpha2", "name", src.Name)
 
 	dst := dstRaw.(*v1alpha2.NodeObservabilityMachineConfig)
 
@@ -52,7 +52,7 @@ func (src *NodeObservabilityMachineConfig) ConvertTo(dstRaw conversion.Hub) erro
 func (dst *NodeObservabilityMachineConfig) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha2.NodeObservabilityMachineConfig)
 
-	webhookNobmcLog.Info("Converting to v1alpha1", "name", src.Name)
+	webhookNobmcLog.V(1).Info("converting to v1alpha1", "name", src.Name)
 
 	// ObjectMeta
 	dst.ObjectMeta = src.ObjectMeta

--- a/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
@@ -375,31 +375,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 20m
-                    memory: 40Mi
-                  requests:
-                    cpu: 10m
-                    memory: 20Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-                  seccompProfile:
-                    type: RuntimeDefault
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
@@ -424,6 +399,10 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz
@@ -445,13 +424,45 @@ spec:
                   seccompProfile:
                     type: RuntimeDefault
                 volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
                 - mountPath: /var/run/secrets/openshift.io/certs
                   name: ca-bundle
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 20m
+                    memory: 40Mi
+                  requests:
+                    cpu: 10m
+                    memory: 20Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  seccompProfile:
+                    type: RuntimeDefault
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: node-observability-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: webhook-server-cert
               - configMap:
                   items:
                   - key: service-ca.crt
@@ -570,7 +581,7 @@ spec:
         serviceAccountName: node-observability-operator-controller-manager
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
@@ -591,3 +602,16 @@ spec:
   - image: quay.io/node-observability-operator/node-observability-agent@sha256:8400109653c7383a66f253114191bf1c57a0966a49944dd18ab02272ae02387e
     name: agent
   version: 0.0.1
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    conversionCRDs:
+    - nodeobservabilities.nodeobservability.olm.openshift.io
+    - nodeobservabilitymachineconfigs.nodeobservability.olm.openshift.io
+    deploymentName: node-observability-operator-controller-manager
+    generateName: cnodeobservabilitiesnodeobservabilitymachineconfigs.kb.io
+    sideEffects: None
+    targetPort: 9443
+    type: ConversionWebhook
+    webhookPath: /convert

--- a/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
           },
           "spec": {
             "labels": {
-              "node-role.kubernetes.io/worker": ""
+              "kubernetes.io/hostname": "worker-a"
             },
             "type": "crio-kubelet"
           }
@@ -50,7 +50,7 @@ metadata:
           },
           "spec": {
             "nodeSelector": {
-              "node-role.kubernetes.io/worker": ""
+              "kubernetes.io/hostname": "worker-a"
             },
             "type": "crio-kubelet"
           }
@@ -66,7 +66,7 @@ metadata:
               "enableCrioProfiling": true
             },
             "nodeSelector": {
-              "node-role.kubernetes.io/worker": ""
+              "kubernetes.io/hostname": "worker-a"
             }
           }
         },
@@ -383,7 +383,7 @@ spec:
                 - --agent-image=$(RELATED_IMAGE_AGENT)
                 env:
                 - name: LOG_LEVEL
-                  value: info
+                  value: debug
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/bundle/manifests/nodeobservability.olm.openshift.io_nodeobservabilities.yaml
+++ b/bundle/manifests/nodeobservability.olm.openshift.io_nodeobservabilities.yaml
@@ -6,6 +6,16 @@ metadata:
   creationTimestamp: null
   name: nodeobservabilities.nodeobservability.olm.openshift.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: node-observability-operator-webhook-service
+          namespace: node-observability-operator
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: nodeobservability.olm.openshift.io
   names:
     kind: NodeObservability

--- a/bundle/manifests/nodeobservability.olm.openshift.io_nodeobservabilitymachineconfigs.yaml
+++ b/bundle/manifests/nodeobservability.olm.openshift.io_nodeobservabilitymachineconfigs.yaml
@@ -6,6 +6,16 @@ metadata:
   creationTimestamp: null
   name: nodeobservabilitymachineconfigs.nodeobservability.olm.openshift.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: node-observability-operator-webhook-service
+          namespace: node-observability-operator
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: nodeobservability.olm.openshift.io
   names:
     kind: NodeObservabilityMachineConfig

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,8 +10,8 @@ resources:
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_nodeobservabilities.yaml
-#- patches/webhook_in_nodeobservabilitymachineconfigs.yaml
+- patches/webhook_in_nodeobservabilities.yaml
+- patches/webhook_in_nodeobservabilitymachineconfigs.yaml
 #- patches/webhook_in_nodeobservabilityruns.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,7 +18,7 @@ bases:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
@@ -35,7 +35,7 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,7 +36,7 @@ spec:
         - "--agent-image=$(RELATED_IMAGE_AGENT)"
         env:
         - name: LOG_LEVEL
-          value: info
+          value: debug
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/config/manifests/bases/node-observability-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-observability-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
   - supported: false
     type: SingleNamespace

--- a/config/samples/nodeobservability_v1alpha1_nodeobservability-all.yaml
+++ b/config/samples/nodeobservability_v1alpha1_nodeobservability-all.yaml
@@ -4,5 +4,5 @@ metadata:
   name: cluster
 spec:
   labels:
-    node-role.kubernetes.io/worker: ""
+    kubernetes.io/hostname: worker-a
   type: crio-kubelet

--- a/config/samples/nodeobservability_v1alpha1_nodeobservability.yaml
+++ b/config/samples/nodeobservability_v1alpha1_nodeobservability.yaml
@@ -4,5 +4,5 @@ metadata:
   name: cluster
 spec:
   labels:
-    node-role.kubernetes.io/worker: ""
+    kubernetes.io/hostname: worker-a
   type: crio-kubelet

--- a/config/samples/nodeobservability_v1alpha2_nodeobservability-all.yaml
+++ b/config/samples/nodeobservability_v1alpha2_nodeobservability-all.yaml
@@ -4,5 +4,5 @@ metadata:
   name: cluster
 spec:
   nodeSelector:
-    node-role.kubernetes.io/worker: ""
+    kubernetes.io/hostname: worker-a
   type: crio-kubelet

--- a/config/samples/nodeobservability_v1alpha2_nodeobservability.yaml
+++ b/config/samples/nodeobservability_v1alpha2_nodeobservability.yaml
@@ -4,5 +4,5 @@ metadata:
   name: cluster
 spec:
   nodeSelector:
-    node-role.kubernetes.io/worker: ""
+    kubernetes.io/hostname: worker-a
   type: crio-kubelet

--- a/config/samples/nodeobservability_v1alpha2_nodeobservabilitymachineconfig.yaml
+++ b/config/samples/nodeobservability_v1alpha2_nodeobservabilitymachineconfig.yaml
@@ -4,6 +4,6 @@ metadata:
   name: sample
 spec:
   nodeSelector:
-    node-role.kubernetes.io/worker: ""
+    kubernetes.io/hostname: worker-a
   debug:
     enableCrioProfiling: true

--- a/hack/add-serving-cert.sh
+++ b/hack/add-serving-cert.sh
@@ -69,5 +69,5 @@ if [ -n "${webhook}" ]; then
 fi
 
 if [ -n "${crd}" ]; then
-    oc annotate crd "${crd}" "service.beta.openshift.io/inject-cabundle=true" --overwrite=true
+    oc annotate crd ${crd} "service.beta.openshift.io/inject-cabundle=true" --overwrite=true
 fi

--- a/hack/add-serving-cert.sh
+++ b/hack/add-serving-cert.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Meant to secure the communication between the API and the webhook server's endpoint
+# using OpenShift's service serving certificate
+
+set -e
+
+usage() {
+  cat <<EOF
+Make the service serving certificates and add the CA bundle to the validating webhook's client config.
+usage: ${0} [OPTIONS]
+The following flags are required.
+    --namespace        Namespace where webhook server resides.
+    --service          Service name of webhook server.
+    --secret           Secret name for CA certificate and server certificate/key pair.
+    --webhook          Validating webhook config name to be injected with CA.
+    --crd              CRD name to be injected with CA.
+EOF
+  exit 1
+}
+
+while [ $# -gt 0 ]; do
+  case ${1} in
+      --service)
+          service="$2"
+          shift
+          ;;
+      --webhook)
+          webhook="$2"
+          shift
+          ;;
+      --crd)
+          crd="$2"
+          shift
+          ;;
+      --secret)
+          secret="$2"
+          shift
+          ;;
+      --namespace)
+          namespace="$2"
+          shift
+          ;;
+      *)
+          usage
+          ;;
+  esac
+  shift
+done
+
+[ -z "${service}" ] && echo "ERROR: --service flag is required" && exit 1
+[ -z "${secret}" ] && echo "ERROR: --secret flag is required" && exit 1
+[ -z "${namespace}" ] && echo "ERROR: --namespace flag is required" && exit 1
+
+if [ -z "${webhook}" ] && [ -z "${crd}" ]; then
+    echo "ERROR: --webhook or --crd flag required"
+    exit 1
+fi
+
+if [ ! -x "$(command -v oc)" ]; then
+  echo "ERROR: oc not found"
+  exit 1
+fi
+
+oc -n "${namespace}" annotate service "${service}" "service.beta.openshift.io/serving-cert-secret-name=${secret}" --overwrite=true
+
+if [ -n "${webhook}" ]; then
+    oc annotate validatingwebhookconfigurations "${webhook}" "service.beta.openshift.io/inject-cabundle=true" --overwrite=true
+fi
+
+if [ -n "${crd}" ]; then
+    oc annotate crd "${crd}" "service.beta.openshift.io/inject-cabundle=true" --overwrite=true
+fi

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 	flag.StringVar(&tokenFile, "token-file", defaultTokenFile, "The path of the service account token.")
 	flag.StringVar(&caCertFile, "ca-cert-file", defaultCACertFile, "The path of the CA cert of the Agents' signing key pair.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. "+"Enabling this will ensure there is only one active controller manager.")
-	flag.BoolVar(&enableWebhook, "enable-webhook", false, "Enable the webhook server(s). Defaults to false.")
+	flag.BoolVar(&enableWebhook, "enable-webhook", true, "Enable the webhook server(s). Defaults to true.")
 	opts := zap.Options{
 		TimeEncoder: zapcore.TimeEncoder(func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 			enc.AppendString(t.UTC().Format("2006-01-02T15:04:05.000Z"))

--- a/test/e2e/nodeobservability_test.go
+++ b/test/e2e/nodeobservability_test.go
@@ -20,15 +20,23 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	operatorv1alpha1 "github.com/openshift/node-observability-operator/api/v1alpha1"
 	operatorv1alpha2 "github.com/openshift/node-observability-operator/api/v1alpha2"
 )
 
 var (
 	ctx = context.Background()
+)
+
+const (
+	hostnameLabel   = "kubernetes.io/hostname"
+	workerRoleLabel = "node-role.kubernetes.io/worker"
 )
 
 var _ = Describe("Node Observability Operator end-to-end test suite", Ordered, func() {
@@ -39,38 +47,38 @@ var _ = Describe("Node Observability Operator end-to-end test suite", Ordered, f
 	BeforeAll(func() {
 		nodeobservability = testNodeObservability()
 		By("deploying Node Observability Agents", func() {
-			Expect(k8sClient.Create(ctx, nodeobservability)).To(Succeed(), "test NodeObservability resource created")
+			Expect(k8sClient.Create(ctx, nodeobservability)).To(Succeed(), "NodeObservability resource is expected to be created")
 			Eventually(func() bool {
 				ds := &appsv1.DaemonSet{}
 				dsNamespacedName := types.NamespacedName{
 					Name:      "node-observability-ds",
-					Namespace: testNamespace,
+					Namespace: operatorNamespace,
 				}
 				Expect(client.IgnoreNotFound(k8sClient.Get(ctx, dsNamespacedName, ds))).To(Succeed())
 				return ds.Status.NumberReady != 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady
 			}, 60, time.Second).Should(BeTrue(), "number of ready agents != number of desired agents")
 		})
 	})
+
 	Context("Happy Path scenario - single scrape is initiated and it is expected to succeed", func() {
 		var (
 			nodeobservabilityRun *operatorv1alpha2.NodeObservabilityRun
 		)
 		BeforeEach(func() {
 			nodeobservabilityRun = testNodeObservabilityRun(defaultTestName)
-
 		})
 
 		It("runs Node Observability scrape", func() {
 
 			By("by initiating the scrape", func() {
-				Expect(k8sClient.Create(ctx, nodeobservabilityRun)).To(Succeed(), "test NodeObservabilityRun resource created")
+				Expect(k8sClient.Create(ctx, nodeobservabilityRun)).To(Succeed(), "NodeObservabilityRun resource is expected to be created")
 			})
 
 			By("by collecting status", func() {
 				run := &operatorv1alpha2.NodeObservabilityRun{}
 				runNamespacedName := types.NamespacedName{
 					Name:      defaultTestName,
-					Namespace: testNamespace,
+					Namespace: operatorNamespace,
 				}
 				Eventually(func() bool {
 					Expect(k8sClient.Get(ctx, runNamespacedName, run)).To(Succeed())
@@ -103,16 +111,16 @@ var _ = Describe("Node Observability Operator end-to-end test suite", Ordered, f
 		It("runs Node Observability scrape", func() {
 
 			By("by creating NORs run2 right after previous test", func() {
-				Expect(k8sClient.Create(ctx, nodeobservabilityRun1)).To(Succeed(), "test NodeObservabilityRun resource created")
+				Expect(k8sClient.Create(ctx, nodeobservabilityRun1)).To(Succeed(), "NodeObservabilityRun resource is expected to be created")
 				time.Sleep(time.Second)
-				Expect(k8sClient.Create(ctx, nodeobservabilityRun2)).To(Succeed(), "test NodeObservabilityRun resource created")
+				Expect(k8sClient.Create(ctx, nodeobservabilityRun2)).To(Succeed(), "NodeObservabilityRun resource is expected to be created")
 			})
 
 			By("by verifying successful status for run1", func() {
 				firstrun := &operatorv1alpha2.NodeObservabilityRun{}
 				runNamespacedName := types.NamespacedName{
 					Name:      run1,
-					Namespace: testNamespace,
+					Namespace: operatorNamespace,
 				}
 				Eventually(func() bool {
 					Expect(k8sClient.Get(ctx, runNamespacedName, firstrun)).To(Succeed())
@@ -125,7 +133,7 @@ var _ = Describe("Node Observability Operator end-to-end test suite", Ordered, f
 				secondrun := &operatorv1alpha2.NodeObservabilityRun{}
 				runNamespacedName := types.NamespacedName{
 					Name:      run2,
-					Namespace: testNamespace,
+					Namespace: operatorNamespace,
 				}
 				Eventually(func() bool {
 					Expect(k8sClient.Get(ctx, runNamespacedName, secondrun)).To(Succeed())
@@ -134,13 +142,122 @@ var _ = Describe("Node Observability Operator end-to-end test suite", Ordered, f
 				Expect(len(secondrun.Status.FailedAgents) > 0).To(BeTrue())
 			})
 		})
+
 		AfterEach(func() {
 			Expect(k8sClient.Delete(ctx, nodeobservabilityRun1)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, nodeobservabilityRun2)).To(Succeed())
 		})
-
 	})
+
 	AfterAll(func() {
-		Expect(k8sClient.Delete(ctx, nodeobservability)).To(Succeed())
+		if !CurrentSpecReport().Failed() {
+			GinkgoWriter.Println("Cleaning up NOB")
+			Expect(k8sClient.Delete(ctx, nodeobservability)).To(Succeed())
+			GinkgoWriter.Println("Waiting for NOBMC to disappear")
+			nobmc := &operatorv1alpha2.NodeObservabilityMachineConfig{}
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: "cluster"}, nobmc))
+			}, 900, time.Second).Should(BeTrue())
+		} else {
+			// keep NOB CR to preserve all the dependent objects
+			GinkgoWriter.Println("Node Observability test has failed, skipping the cleanup of NOB")
+			// aborting the rest of the tests as they create their own NOBs
+			// which will result into a conflict
+			AbortSuite("Aborting whole test suite to avoid conflicts")
+		}
+	})
+})
+
+var _ = Describe("Node Observability Operator end-to-end test suite using v1alpha1", Ordered, func() {
+	var (
+		nodeobservability *operatorv1alpha1.NodeObservability
+	)
+
+	BeforeAll(func() {
+		// observe only 1 node to speed up the test
+		nodeobservability = &operatorv1alpha1.NodeObservability{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster",
+			},
+			Spec: operatorv1alpha1.NodeObservabilitySpec{
+				Labels: map[string]string{
+					hostnameLabel: nodesWithoutOperator.Items[0].Labels[hostnameLabel],
+				},
+				Type: operatorv1alpha1.CrioKubeletNodeObservabilityType,
+			},
+		}
+		By("deploying Node Observability Agents", func() {
+			Expect(k8sClient.Create(ctx, nodeobservability)).To(Succeed(), "NodeObservability resource is expected to be created")
+			Eventually(func() bool {
+				ds := &appsv1.DaemonSet{}
+				dsNamespacedName := types.NamespacedName{
+					Name:      "node-observability-ds",
+					Namespace: operatorNamespace,
+				}
+				Expect(client.IgnoreNotFound(k8sClient.Get(ctx, dsNamespacedName, ds))).To(Succeed())
+				return ds.Status.NumberReady != 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady
+			}, 60, time.Second).Should(BeTrue(), "number of ready agents != number of desired agents")
+		})
+	})
+	Context("Happy Path scenario - single scrape is initiated and it is expected to succeed", func() {
+		var (
+			nodeobservabilityRun *operatorv1alpha1.NodeObservabilityRun
+		)
+		BeforeEach(func() {
+			nodeobservabilityRun = &operatorv1alpha1.NodeObservabilityRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaultTestName,
+					Namespace: operatorNamespace,
+				},
+				Spec: operatorv1alpha1.NodeObservabilityRunSpec{
+					NodeObservabilityRef: &operatorv1alpha1.NodeObservabilityRef{
+						Name: "cluster",
+					},
+				},
+			}
+		})
+
+		It("runs Node Observability scrape", func() {
+
+			By("by initiating the scrape", func() {
+				Expect(k8sClient.Create(ctx, nodeobservabilityRun)).To(Succeed(), "NodeObservabilityRun resource is expected to be created")
+				GinkgoWriter.Println("Creation of NOB run done")
+			})
+
+			By("by collecting status", func() {
+				run := &operatorv1alpha1.NodeObservabilityRun{}
+				runNamespacedName := types.NamespacedName{
+					Name:      defaultTestName,
+					Namespace: operatorNamespace,
+				}
+				Eventually(func() bool {
+					Expect(k8sClient.Get(ctx, runNamespacedName, run)).To(Succeed(), "NOB run is expected to exist")
+					return run.Status.FinishedTimestamp.IsZero()
+				}, 600, time.Second).Should(BeFalse())
+				Expect(run.Status.FailedAgents).To(BeEmpty(), "Failed agent list is expected to be empty")
+			})
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(ctx, nodeobservabilityRun)).To(Succeed())
+		})
+	})
+
+	AfterAll(func() {
+		if !CurrentSpecReport().Failed() {
+			GinkgoWriter.Println("Cleaning up NOB")
+			Expect(k8sClient.Delete(ctx, nodeobservability)).To(Succeed())
+			GinkgoWriter.Println("Waiting for NOBMC to disappear")
+			nobmc := &operatorv1alpha1.NodeObservabilityMachineConfig{}
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: "cluster"}, nobmc))
+			}, 600, time.Second).Should(BeTrue())
+		} else {
+			// keep NOB CR to preserve all the dependent objects
+			GinkgoWriter.Println("Node Observability test for v1alpha1 has failed, skipping the cleanup of NOB")
+			// aborting the rest of the tests as they create their own NOBs
+			// which will result into a conflict
+			AbortSuite("Aborting whole test suite to avoid conflicts")
+		}
 	})
 })

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -22,6 +22,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	securityv1 "github.com/openshift/api/security/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -31,6 +33,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	nodeobservabilityv1alpha1 "github.com/openshift/node-observability-operator/api/v1alpha1"
 	nodeobservabilityv1alpha2 "github.com/openshift/node-observability-operator/api/v1alpha2"
 	//+kubebuilder:scaffold:imports
 )
@@ -38,17 +41,23 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 
+// nodesWithoutOperator is a list of nodes on which the operator is not scheduled,
+// restarting them is not supposed to result in the loss of the operator logs.
+var nodesWithoutOperator *corev1.NodeList
+
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t,
-		"Controller Suite")
+	RunSpecs(t, "Node Observability Suite")
 }
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	err := nodeobservabilityv1alpha2.AddToScheme(scheme.Scheme)
+	err := nodeobservabilityv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = nodeobservabilityv1alpha2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = clientgoscheme.AddToScheme(scheme.Scheme)
@@ -66,4 +75,24 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
+	expected := []appsv1.DeploymentCondition{
+		{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+	}
+	err = waitForOperatorDeploymentStatusCondition(k8sClient, expected...)
+	Expect(err).NotTo(HaveOccurred(), "Operator is expected to be available")
+
+	opNodeName, err := operatorScheduledNodeName(k8sClient)
+	Expect(err).NotTo(HaveOccurred(), "Listing of operator POD is expected to succeed")
+	Expect(opNodeName).NotTo(BeEmpty(), "Operator POD is expected to be scheduled")
+
+	nodesWithoutOperator = &corev1.NodeList{}
+	nodes := &corev1.NodeList{}
+	Expect(k8sClient.List(ctx, nodes, client.MatchingLabels(map[string]string{workerRoleLabel: ""}))).To(Succeed(), "List of nodes is expected to be retrieved")
+	Expect(len(nodes.Items)).To(Not(BeZero()))
+	for _, n := range nodes.Items {
+		if n.Name != opNodeName {
+			nodesWithoutOperator.Items = append(nodesWithoutOperator.Items, n)
+		}
+	}
+	Expect(len(nodesWithoutOperator.Items)).To(Not(BeZero()))
 })

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1,23 +1,34 @@
 package e2e
 
 import (
+	"context"
+	"reflect"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1alpha2 "github.com/openshift/node-observability-operator/api/v1alpha2"
 	//+kubebuilder:scaffold:imports
 )
 
 const (
-	defaultTestName = "test-instance"
-	testNamespace   = "node-observability-operator"
+	defaultTestName        = "test-instance"
+	operatorNamespace      = "node-observability-operator"
+	operatorDeploymentName = "node-observability-operator-controller-manager"
 )
 
 // testNodeObservability - minimal CR for the test
 func testNodeObservability() *operatorv1alpha2.NodeObservability {
 	return &operatorv1alpha2.NodeObservability{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cluster",
-			Namespace: testNamespace,
+			Name: "cluster",
 		},
 		Spec: operatorv1alpha2.NodeObservabilitySpec{
 			NodeSelector: map[string]string{
@@ -33,7 +44,7 @@ func testNodeObservabilityRun(testName string) *operatorv1alpha2.NodeObservabili
 	return &operatorv1alpha2.NodeObservabilityRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
-			Namespace: testNamespace,
+			Namespace: operatorNamespace,
 		},
 		Spec: operatorv1alpha2.NodeObservabilityRunSpec{
 			NodeObservabilityRef: &operatorv1alpha2.NodeObservabilityRef{
@@ -41,4 +52,55 @@ func testNodeObservabilityRun(testName string) *operatorv1alpha2.NodeObservabili
 			},
 		},
 	}
+}
+
+// waitForOperatorDeploymentStatusCondition waits for the given condition(s) on the operator deployment.
+func waitForOperatorDeploymentStatusCondition(cl client.Client, conditions ...appsv1.DeploymentCondition) error {
+	return wait.Poll(2*time.Second, 1*time.Minute, func() (bool, error) {
+		dep := &appsv1.Deployment{}
+		name := types.NamespacedName{
+			Name:      operatorDeploymentName,
+			Namespace: operatorNamespace,
+		}
+		if err := cl.Get(context.TODO(), name, dep); err != nil {
+			return false, nil
+		}
+
+		expected := deploymentConditionMap(conditions...)
+		current := deploymentConditionMap(dep.Status.Conditions...)
+		return conditionsMatchExpected(expected, current), nil
+	})
+}
+
+// operatorScheduledNodeName returns the node name assigned to the operator's POD.
+func operatorScheduledNodeName(cl client.Client) (string, error) {
+	pods := &corev1.PodList{}
+	if err := cl.List(context.TODO(), pods, client.InNamespace(operatorNamespace)); err != nil {
+		return "", err
+	}
+
+	for _, p := range pods.Items {
+		if strings.HasPrefix(p.Name, operatorDeploymentName) {
+			return p.Spec.NodeName, nil
+		}
+	}
+	return "", nil
+}
+
+func deploymentConditionMap(conditions ...appsv1.DeploymentCondition) map[string]string {
+	conds := map[string]string{}
+	for _, cond := range conditions {
+		conds[string(cond.Type)] = string(cond.Status)
+	}
+	return conds
+}
+
+func conditionsMatchExpected(expected, actual map[string]string) bool {
+	filtered := map[string]string{}
+	for k := range actual {
+		if _, comparable := expected[k]; comparable {
+			filtered[k] = actual[k]
+		}
+	}
+	return reflect.DeepEqual(expected, filtered)
 }


### PR DESCRIPTION
Followup of https://github.com/openshift/node-observability-operator/pull/89:
- Conversion webhook in the manifests enabled
- Convenience script to setup cluster certificate for the conversion webhook added
- e2e test scenario with `v1alpha1` version added:
    - changes put into a separate commit
    - 2 `nob`s are created now, so the cleanup has to be reliable, that's what the most of the code is doing
    - e2e now expects the operator to be available
    - more logs added
- samples updated to be more specific on `nodeSelector`
- `debug` is set as default log level, since it's still quite a young and often unstable operator