### PR TITLE
related agent image: use dedicated quay.io organization

### DIFF
--- a/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
@@ -414,7 +414,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: RELATED_IMAGE_AGENT
-                  value: quay.io/openshift/origin-node-observability-agent@sha256:df9d74943a8ce23a7ef1b194e482697e8a550e1a98ba103f90ebdc869f3d5112
+                  value: quay.io/node-observability-operator/node-observability-agent@sha256:8400109653c7383a66f253114191bf1c57a0966a49944dd18ab02272ae02387e
                 image: quay.io/openshift/node-observability-operator:v0.0.1
                 imagePullPolicy: Always
                 livenessProbe:
@@ -588,6 +588,6 @@ spec:
   provider:
     name: Red Hat, Inc.
   relatedImages:
-  - image: quay.io/openshift/origin-node-observability-agent@sha256:df9d74943a8ce23a7ef1b194e482697e8a550e1a98ba103f90ebdc869f3d5112
+  - image: quay.io/node-observability-operator/node-observability-agent@sha256:8400109653c7383a66f253114191bf1c57a0966a49944dd18ab02272ae02387e
     name: agent
   version: 0.0.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,8 +42,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_AGENT
-          # agent commit id: a380581b3f0fec4d35eeee4fb59ab4d83d2a989c
-          value: quay.io/openshift/origin-node-observability-agent@sha256:df9d74943a8ce23a7ef1b194e482697e8a550e1a98ba103f90ebdc869f3d5112
+          # agent commit id: 5180057970e296b2808bbab72fbf3e27cf28ed1d
+          value: quay.io/node-observability-operator/node-observability-agent@sha256:8400109653c7383a66f253114191bf1c57a0966a49944dd18ab02272ae02387e
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
The agent image is now mirrored into the dedicated organization: https://quay.io/organization/node-observability-operator.