### PR TITLE
nob controller: watch all secondary resources

### DIFF
--- a/config/samples/nodeobservability_v1alpha1_nodeobservability-all.yaml
+++ b/config/samples/nodeobservability_v1alpha1_nodeobservability-all.yaml
@@ -4,5 +4,5 @@ metadata:
   name: cluster
 spec:
   labels:
-    kubernetes.io/hostname: worker-a
+    node-role.kubernetes.io/worker: ""
   type: crio-kubelet

--- a/config/samples/nodeobservability_v1alpha2_nodeobservability-all.yaml
+++ b/config/samples/nodeobservability_v1alpha2_nodeobservability-all.yaml
@@ -4,5 +4,5 @@ metadata:
   name: cluster
 spec:
   nodeSelector:
-    kubernetes.io/hostname: worker-a
+    node-role.kubernetes.io/worker: ""
   type: crio-kubelet

--- a/pkg/operator/controller/nodeobservability/scc_test.go
+++ b/pkg/operator/controller/nodeobservability/scc_test.go
@@ -199,3 +199,185 @@ func TestDeleteSCC(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateScc(t *testing.T) {
+	testCases := []struct {
+		name            string
+		desired         *securityv1.SecurityContextConstraints
+		current         *securityv1.SecurityContextConstraints
+		expectedUpdated bool
+		errExpected     bool
+	}{
+		{
+			name: "Order should not matter for some fields",
+			desired: &securityv1.SecurityContextConstraints{
+				ObjectMeta:               metav1.ObjectMeta{Name: sccName, ResourceVersion: "1"},
+				AllowPrivilegedContainer: true,
+				DefaultAddCapabilities:   []corev1.Capability{"KILL", "SYSLOG"},
+				RequiredDropCapabilities: []corev1.Capability{"MKNOD", "SYS_ADMIN"},
+				AllowedCapabilities:      []corev1.Capability{"KILL", "SYSLOG"},
+				AllowHostDirVolumePlugin: true,
+				Volumes:                  []securityv1.FSType{securityv1.FSTypeHostPath, securityv1.FSTypeSecret, securityv1.FSTypeConfigMap},
+				AllowHostNetwork:         false,
+				AllowHostPorts:           false,
+				AllowHostPID:             false,
+				AllowHostIPC:             false,
+				SELinuxContext:           securityv1.SELinuxContextStrategyOptions{Type: securityv1.SELinuxStrategyMustRunAs},
+				RunAsUser:                securityv1.RunAsUserStrategyOptions{Type: securityv1.RunAsUserStrategyRunAsAny},
+				SupplementalGroups:       securityv1.SupplementalGroupsStrategyOptions{Type: securityv1.SupplementalGroupsStrategyRunAsAny},
+				FSGroup:                  securityv1.FSGroupStrategyOptions{Type: securityv1.FSGroupStrategyRunAsAny},
+				ReadOnlyRootFilesystem:   false,
+				AllowedUnsafeSysctls:     []string{"kernel.msg*", "net.core.somaxconn"},
+				ForbiddenSysctls:         []string{"kernel.sem", "net.*"},
+				SeccompProfiles:          []string{"runtime/default", "localhost"},
+				Groups:                   []string{"system:cluster-admins", "system:nodes"},
+			},
+			current: &securityv1.SecurityContextConstraints{
+				ObjectMeta:               metav1.ObjectMeta{Name: sccName, ResourceVersion: "1"},
+				AllowPrivilegedContainer: true,
+				DefaultAddCapabilities:   []corev1.Capability{"SYSLOG", "KILL"},     // different order
+				RequiredDropCapabilities: []corev1.Capability{"SYS_ADMIN", "MKNOD"}, // different order
+				AllowedCapabilities:      []corev1.Capability{"SYSLOG", "KILL"},     // different order
+				AllowHostDirVolumePlugin: true,
+				Volumes:                  []securityv1.FSType{securityv1.FSTypeSecret, securityv1.FSTypeHostPath, securityv1.FSTypeConfigMap}, // different order
+				AllowHostNetwork:         false,
+				AllowHostPorts:           false,
+				AllowHostPID:             false,
+				AllowHostIPC:             false,
+				SELinuxContext:           securityv1.SELinuxContextStrategyOptions{Type: securityv1.SELinuxStrategyMustRunAs},
+				RunAsUser:                securityv1.RunAsUserStrategyOptions{Type: securityv1.RunAsUserStrategyRunAsAny},
+				SupplementalGroups:       securityv1.SupplementalGroupsStrategyOptions{Type: securityv1.SupplementalGroupsStrategyRunAsAny},
+				FSGroup:                  securityv1.FSGroupStrategyOptions{Type: securityv1.FSGroupStrategyRunAsAny},
+				ReadOnlyRootFilesystem:   false,
+				AllowedUnsafeSysctls:     []string{"net.core.somaxconn", "kernel.msg*"}, // different order
+				ForbiddenSysctls:         []string{"net.*", "kernel.sem"},               // different order
+				SeccompProfiles:          []string{"localhost", "runtime/default"},      // different order
+				Groups:                   []string{"system:cluster-admins", "system:nodes"},
+			},
+			expectedUpdated: false,
+		},
+		{
+			name: "Some fields should ignored",
+			desired: &securityv1.SecurityContextConstraints{
+				ObjectMeta:               metav1.ObjectMeta{Name: sccName, ResourceVersion: "1"},
+				AllowPrivilegedContainer: true,
+				DefaultAddCapabilities:   []corev1.Capability{"KILL", "SYSLOG"},
+				RequiredDropCapabilities: []corev1.Capability{"MKNOD", "SYS_ADMIN"},
+				AllowedCapabilities:      []corev1.Capability{"KILL", "SYSLOG"},
+				AllowHostDirVolumePlugin: true,
+				Volumes:                  []securityv1.FSType{securityv1.FSTypeHostPath, securityv1.FSTypeSecret, securityv1.FSTypeConfigMap},
+				AllowHostNetwork:         false,
+				AllowHostPorts:           false,
+				AllowHostPID:             false,
+				AllowHostIPC:             false,
+				SELinuxContext:           securityv1.SELinuxContextStrategyOptions{Type: securityv1.SELinuxStrategyMustRunAs},
+				RunAsUser:                securityv1.RunAsUserStrategyOptions{Type: securityv1.RunAsUserStrategyRunAsAny},
+				SupplementalGroups:       securityv1.SupplementalGroupsStrategyOptions{Type: securityv1.SupplementalGroupsStrategyRunAsAny},
+				FSGroup:                  securityv1.FSGroupStrategyOptions{Type: securityv1.FSGroupStrategyRunAsAny},
+				ReadOnlyRootFilesystem:   false,
+				AllowedUnsafeSysctls:     []string{"kernel.msg*", "net.core.somaxconn"},
+				ForbiddenSysctls:         []string{"kernel.sem", "net.*"},
+				SeccompProfiles:          []string{"runtime/default", "localhost"},
+				Groups:                   []string{"system:cluster-admins", "system:nodes"},
+			},
+			current: &securityv1.SecurityContextConstraints{
+				ObjectMeta:               metav1.ObjectMeta{Name: sccName, ResourceVersion: "1"},
+				AllowPrivilegedContainer: true,
+				DefaultAddCapabilities:   []corev1.Capability{"KILL", "SYSLOG"},
+				RequiredDropCapabilities: []corev1.Capability{"MKNOD", "SYS_ADMIN"},
+				AllowedCapabilities:      []corev1.Capability{"KILL", "SYSLOG"},
+				AllowHostDirVolumePlugin: true,
+				Volumes:                  []securityv1.FSType{securityv1.FSTypeHostPath, securityv1.FSTypeSecret, securityv1.FSTypeConfigMap},
+				AllowHostNetwork:         false,
+				AllowHostPorts:           false,
+				AllowHostPID:             false,
+				AllowHostIPC:             false,
+				SELinuxContext:           securityv1.SELinuxContextStrategyOptions{Type: securityv1.SELinuxStrategyMustRunAs},
+				RunAsUser:                securityv1.RunAsUserStrategyOptions{Type: securityv1.RunAsUserStrategyRunAsAny},
+				SupplementalGroups:       securityv1.SupplementalGroupsStrategyOptions{Type: securityv1.SupplementalGroupsStrategyRunAsAny},
+				FSGroup:                  securityv1.FSGroupStrategyOptions{Type: securityv1.FSGroupStrategyRunAsAny},
+				ReadOnlyRootFilesystem:   false,
+				AllowedUnsafeSysctls:     []string{"kernel.msg*", "net.core.somaxconn"},
+				ForbiddenSysctls:         []string{"kernel.sem", "net.*"},
+				SeccompProfiles:          []string{"runtime/default", "localhost"},
+				Groups:                   []string{"system:cluster-admins", "system:nodes", "system:master"}, // ignored
+				Users:                    []string{"system:serviceaccount:openshift-infra:default"},          // ignored
+			},
+			expectedUpdated: false,
+		},
+		{
+			name: "Should be updated",
+			desired: &securityv1.SecurityContextConstraints{
+				ObjectMeta:               metav1.ObjectMeta{Name: sccName, ResourceVersion: "1"},
+				AllowPrivilegedContainer: true,
+				DefaultAddCapabilities:   []corev1.Capability{"KILL", "SYSLOG"},
+				RequiredDropCapabilities: []corev1.Capability{"MKNOD", "SYS_ADMIN"},
+				AllowedCapabilities:      []corev1.Capability{"KILL", "SYSLOG"},
+				AllowHostDirVolumePlugin: true,
+				Volumes:                  []securityv1.FSType{securityv1.FSTypeHostPath, securityv1.FSTypeSecret, securityv1.FSTypeConfigMap},
+				AllowHostNetwork:         false,
+				AllowHostPorts:           false,
+				AllowHostPID:             false,
+				AllowHostIPC:             false,
+				SELinuxContext:           securityv1.SELinuxContextStrategyOptions{Type: securityv1.SELinuxStrategyMustRunAs},
+				RunAsUser:                securityv1.RunAsUserStrategyOptions{Type: securityv1.RunAsUserStrategyRunAsAny},
+				SupplementalGroups:       securityv1.SupplementalGroupsStrategyOptions{Type: securityv1.SupplementalGroupsStrategyRunAsAny},
+				FSGroup:                  securityv1.FSGroupStrategyOptions{Type: securityv1.FSGroupStrategyRunAsAny},
+				ReadOnlyRootFilesystem:   false,
+				AllowedUnsafeSysctls:     []string{"kernel.msg*", "net.core.somaxconn"},
+				ForbiddenSysctls:         []string{"kernel.sem", "net.*"},
+				SeccompProfiles:          []string{"runtime/default", "localhost"},
+				Groups:                   []string{"system:cluster-admins", "system:nodes"},
+			},
+			current: &securityv1.SecurityContextConstraints{
+				ObjectMeta:               metav1.ObjectMeta{Name: sccName, ResourceVersion: "1"},
+				AllowPrivilegedContainer: true,
+				DefaultAddCapabilities:   []corev1.Capability{"KILL", "SYSLOG"},
+				RequiredDropCapabilities: []corev1.Capability{"MKNOD", "SYS_ADMIN"},
+				AllowedCapabilities:      []corev1.Capability{"KILL", "SYSLOG"},
+				AllowHostDirVolumePlugin: true,
+				Volumes:                  []securityv1.FSType{securityv1.FSTypeHostPath, securityv1.FSTypeSecret, securityv1.FSTypeConfigMap},
+				AllowHostNetwork:         false,
+				AllowHostPorts:           false,
+				AllowHostPID:             false,
+				AllowHostIPC:             true, // undesired
+				SELinuxContext:           securityv1.SELinuxContextStrategyOptions{Type: securityv1.SELinuxStrategyMustRunAs},
+				RunAsUser:                securityv1.RunAsUserStrategyOptions{Type: securityv1.RunAsUserStrategyRunAsAny},
+				SupplementalGroups:       securityv1.SupplementalGroupsStrategyOptions{Type: securityv1.SupplementalGroupsStrategyRunAsAny},
+				FSGroup:                  securityv1.FSGroupStrategyOptions{Type: securityv1.FSGroupStrategyRunAsAny},
+				ReadOnlyRootFilesystem:   false,
+				AllowedUnsafeSysctls:     []string{"kernel.msg*", "net.core.somaxconn"},
+				ForbiddenSysctls:         []string{"kernel.sem", "net.*"},
+				SeccompProfiles:          []string{"runtime/default", "localhost"},
+				Groups:                   []string{"system:cluster-admins", "system:nodes", "system:master"},
+				Users:                    []string{"system:serviceaccount:openshift-infra:default"},
+			},
+			expectedUpdated: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().WithScheme(test.Scheme).WithRuntimeObjects(tc.current).Build()
+			r := &NodeObservabilityReconciler{
+				Client: cl,
+				Scheme: test.Scheme,
+				Log:    zap.New(zap.UseDevMode(true)),
+			}
+			gotUpdated, err := r.updateSecurityContextConstraintes(context.TODO(), tc.current, tc.desired)
+			if err != nil {
+				if !tc.errExpected {
+					t.Fatalf("Unexpected error received: %v", err)
+				}
+				return
+			}
+			if tc.errExpected {
+				t.Fatalf("Error expected but wasn't received")
+			}
+
+			if gotUpdated != tc.expectedUpdated {
+				t.Fatalf("Expected SCC to be updated %t but got %t", tc.expectedUpdated, gotUpdated)
+			}
+		})
+	}
+}

--- a/pkg/operator/controller/utils/predicates.go
+++ b/pkg/operator/controller/utils/predicates.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2022.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HasName returns a predicate which checks whether an object has the given name.
+func HasName(name string) func(o client.Object) bool {
+	return func(o client.Object) bool {
+		return o.GetName() == name
+	}
+}


### PR DESCRIPTION
- Requeue `NodeObservability` if any of its secondary resources is touched. SCC, service and serviceaccounts were missing.
- SCC update function was changed to disregard the order of some fields: volumes, capabilities (saw the fight with OpenShift defaulting).
- DaemonSet volumesChanged function was changed to disregard `defaultMode` field (saw the fight with OpenShift defaulting).

SCC:
```
$ oc logs deploy/node-observability-operator-controller-manager -c manager | grep -c 'updated securitycontextconstraints'
0

$ oc patch scc node-observability-agent --type='json' -p='[{"op": "replace", "path": "/allowPrivilegedContainer", "value":false}]'
securitycontextconstraints.security.openshift.io/node-observability-agent patched

$ oc logs deploy/node-observability-operator-controller-manager -c manager | grep -c 'updated securitycontextconstraints'
1
```

Service:
```
$ oc get svc node-observability-agent
NAME                       TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
node-observability-agent   ClusterIP   None         <none>        8443/TCP   162m

$ oc logs deploy/node-observability-operator-controller-manager -c manager | grep -c 'updated service'
0

$ oc patch svc node-observability-agent --type='json' -p='[{"op": "replace", "path": "/spec/ports/0/port", "value":9999}]'
service/node-observability-agent patched

$ oc logs deploy/node-observability-operator-controller-manager -c manager | grep -c 'updated service'
1
```

ServiceAccount:
```
$ oc get sa node-observability-agent
NAME                       SECRETS   AGE
node-observability-agent   1         156m

$ oc logs deploy/node-observability-operator-controller-manager -c manager | grep -c 'created serviceaccount'
0

$ oc delete sa node-observability-agent
serviceaccount "node-observability-agent" deleted

$ oc logs deploy/node-observability-operator-controller-manager -c manager | grep -c 'created serviceaccount'
1
```