### PR TITLE
Bump agent 6e637bb1494d87d8e4983704f6d83a7331a61dda

### DIFF
--- a/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
@@ -391,7 +391,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: RELATED_IMAGE_AGENT
-                  value: quay.io/node-observability-operator/node-observability-agent@sha256:8400109653c7383a66f253114191bf1c57a0966a49944dd18ab02272ae02387e
+                  value: quay.io/node-observability-operator/node-observability-agent@sha256:ac858cd54e895a61de6fb537d79a3f1245ffb4a1f12c81bade7d28168bd5951f
                 image: quay.io/openshift/node-observability-operator:v0.0.1
                 imagePullPolicy: Always
                 livenessProbe:
@@ -573,7 +573,7 @@ spec:
   provider:
     name: Red Hat, Inc.
   relatedImages:
-  - image: quay.io/node-observability-operator/node-observability-agent@sha256:8400109653c7383a66f253114191bf1c57a0966a49944dd18ab02272ae02387e
+  - image: quay.io/node-observability-operator/node-observability-agent@sha256:ac858cd54e895a61de6fb537d79a3f1245ffb4a1f12c81bade7d28168bd5951f
     name: agent
   version: 0.0.1
   webhookdefinitions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,8 +42,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: RELATED_IMAGE_AGENT
-          # agent commit id: 5180057970e296b2808bbab72fbf3e27cf28ed1d
-          value: quay.io/node-observability-operator/node-observability-agent@sha256:8400109653c7383a66f253114191bf1c57a0966a49944dd18ab02272ae02387e
+          # agent commit id: 6e637bb1494d87d8e4983704f6d83a7331a61dda
+          value: quay.io/node-observability-operator/node-observability-agent@sha256:ac858cd54e895a61de6fb537d79a3f1245ffb4a1f12c81bade7d28168bd5951f
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/operator/controller/nodeobservability/daemonset.go
+++ b/pkg/operator/controller/nodeobservability/daemonset.go
@@ -138,7 +138,9 @@ func (r *NodeObservabilityReconciler) updateDaemonset(ctx context.Context, curre
 // desiredDaemonSet returns a DaemonSet object
 func (r *NodeObservabilityReconciler) desiredDaemonSet(nodeObs *v1alpha2.NodeObservability, sa *corev1.ServiceAccount, ns string) *appsv1.DaemonSet {
 	ls := labelsForNodeObservability(nodeObs.Name)
-	tgp := int64(30)
+	// profiling probe currently takes 30 seconds (default),
+	// giving enough time to gracefully finish all the profiling requests
+	tgp := int64(45)
 	vst := corev1.HostPathSocket
 	privileged := true
 

--- a/pkg/operator/controller/nodeobservability/daemonset_test.go
+++ b/pkg/operator/controller/nodeobservability/daemonset_test.go
@@ -627,7 +627,7 @@ func (b *testDaemonsetBuilder) build() *appsv1.DaemonSet {
 					ServiceAccountName:            b.serviceAccount,
 					Volumes:                       b.volumes,
 					NodeSelector:                  b.nodeSelector,
-					TerminationGracePeriodSeconds: pointer.Int64(30),
+					TerminationGracePeriodSeconds: pointer.Int64(45),
 				},
 			},
 		},


### PR DESCRIPTION
Bump to the latest agent image containing [this commit](https://github.com/openshift/node-observability-agent/commit/6e637bb1494d87d8e4983704f6d83a7331a61dda).
Graceful termination of the ongoing profile requests has been added in the agent. The graceful period was increased to let any profiling probe finish.