### PR TITLE
CFE-600: CI to look for `build_root_image` from this repo

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-8-release-golang-1.19-openshift-4.12


### PR DESCRIPTION
CI to look for `build_root_image` from this repo

This is to enable/unblock the CI config change https://github.com/openshift/release/pull/33281

Signed-off-by: Sai Ramesh Vanka <svanka@redhat.com>