### PR TITLE
CFE-634: nob controller: reload kubelet CA configmap

### DIFF
--- a/pkg/operator/controller/nodeobservability/daemonset_util.go
+++ b/pkg/operator/controller/nodeobservability/daemonset_util.go
@@ -1,6 +1,8 @@
 package nodeobservabilitycontroller
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"reflect"
 	"sort"
 
@@ -235,4 +237,24 @@ func equalBoolPtr(current, desired *bool) bool {
 	}
 
 	return *current == *desired
+}
+
+func buildMapHash(data map[string]string) (string, error) {
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	hash := sha256.New()
+	for _, k := range keys {
+		_, err := hash.Write([]byte(k))
+		if err != nil {
+			return "", err
+		}
+		_, err = hash.Write([]byte(data[k]))
+		if err != nil {
+			return "", err
+		}
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }


### PR DESCRIPTION
Followup of https://github.com/openshift/node-observability-operator/pull/111.
The ca-configmap controller syncs the kubelet CA configmap from `openshift-config-managed` namespace into NOB operator's namespace. The agent daemonset consumes the synced configmap. However the configmap may change (certificate rotation). The ca-configmap controller would sync the contents and the kubelet (on the node where agent POD is scheduled) would update the contents in the volume mounted by the agent's POD. But the agent's process doesn't know that the CA bundle changed on the filesystem.

The PR aims at bridging this gap. The POD spec is changed every time there are new contents of the kubelet CA configmap from the operator's namespace. The change consist in the update of the annotation with the hash of the configmap's data.