### PR TITLE
release 0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the BUNDLE_VERSION as arg of the bundle target (e.g make bundle BUNDLE_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export BUNDLE_VERSION=0.0.2)
-BUNDLE_VERSION ?= 0.0.1
+BUNDLE_VERSION ?= 0.2.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
@@ -85,11 +85,12 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    olm.skipRange: <0.2.0
     operatorframework.io/suggested-namespace: node-observability-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform"]'
     operators.operatorframework.io/builder: operator-sdk-v1.18.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: node-observability-operator.v0.0.1
+  name: node-observability-operator.v0.2.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -574,7 +575,7 @@ spec:
   relatedImages:
   - image: quay.io/node-observability-operator/node-observability-agent@sha256:977a6adc59ac1467d9f6d1a77854593786b8c43e36111a50925acd64d58e15a6
     name: agent
-  version: 0.0.1
+  version: 0.2.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manifests/bases/node-observability-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-observability-operator.clusterserviceversion.yaml
@@ -4,9 +4,10 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    olm.skipRange: <0.2.0
     operatorframework.io/suggested-namespace: node-observability-operator
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform"]'
-  name: node-observability-operator.v0.0.1
+  name: node-observability-operator.v0.2.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -78,4 +79,4 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat, Inc.
-  version: 0.1.0
+  version: 0.2.0


### PR DESCRIPTION
`alpha` channel is kept to force the migration to the new version of the operator.