### PR TITLE
Upgrades operator-sdk, builder and base images

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
 # TODO: Switch to UBI golang image when 1.17 is released
 # FROM registry.access.redhat.com/ubi8/go-toolset:latest
 
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build-operator
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.ci.openshift.org/ocp/4.12:base
+FROM registry.ci.openshift.org/ocp/4.13:base
 WORKDIR /
 COPY --from=builder /workspace/bin/node-observability-operator .
 USER 65532:65532

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the BUNDLE_VERSION as arg of the bundle target (e.g make bundle BUNDLE_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export BUNDLE_VERSION=0.0.2)
-BUNDLE_VERSION ?= 0.2.0
+BUNDLE_VERSION ?= 0.3.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -45,7 +45,7 @@ IMG_VERSION ?= v0.0.1
 IMG ?= $(IMAGE_TAG_BASE):$(IMG_VERSION)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
+ENVTEST_K8S_VERSION = 1.25
 
 # CONTAINER_ENGINE defines which container executable to use
 CONTAINER_ENGINE ?= podman
@@ -83,7 +83,7 @@ E2E_TIMEOUT ?= 1h
 BUNDLE_DIR := bundle
 BUNDLE_MANIFEST_DIR := $(BUNDLE_DIR)/manifests
 
-OPERATOR_SDK_VERSION = v1.19.0
+OPERATOR_SDK_VERSION = v1.28.0
 
 OPERATOR_SDK_BIN = $(shell pwd)/bin/operator-sdk
 .PHONY: operator-sdk

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=node-observability-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.18.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
@@ -85,11 +85,12 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    createdAt: "2023-04-05T09:19:44Z"
     olm.skipRange: <0.2.0
     operatorframework.io/suggested-namespace: node-observability-operator
-    operators.operatorframework.io/builder: operator-sdk-v1.18.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: node-observability-operator.v0.2.0
+  name: node-observability-operator.v0.3.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -574,7 +575,7 @@ spec:
   relatedImages:
   - image: quay.io/node-observability-operator/node-observability-agent@sha256:977a6adc59ac1467d9f6d1a77854593786b8c43e36111a50925acd64d58e15a6
     name: agent
-  version: 0.2.0
+  version: 0.3.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,15 +5,10 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: node-observability-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.18.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-
-  # should this operator be supported on OCP 4.4 and earlier (old appregistry format)
-  com.redhat.delivery.backport: false
-  # this is a bundle image and should be delivered via an index image
-  com.redhat.delivery.operator.bundle: true


### PR DESCRIPTION
operator-sdk   => 1.28.0
base image     => registry.ci.openshift.org/ocp/4.13:base
builder image  => registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14