### PR TITLE
Fix typo in dockerfile

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -9,7 +9,7 @@ LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.18.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
-LABEL operators.openshift.io/valid-subscription: "OpenShift Container Platform"
+LABEL operators.openshift.io/valid-subscription="OpenShift Container Platform"
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/


### PR DESCRIPTION
In the previous PR I added the LABEL to the Dockerfile with a typo. This PR fixes this