### PR TITLE
Remove label, causing CPaaS build to fail

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -9,7 +9,6 @@ LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.18.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
-LABEL operators.openshift.io/valid-subscription="OpenShift Container Platform"
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/


### PR DESCRIPTION
Removed this label as its causing a failure in CPaaS

`LABEL operators.openshift.io/valid-subscription="OpenShift Container Platform"`