### PR TITLE
CFE-930:  Add label array for valid-subscriptions

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -9,7 +9,6 @@ LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.18.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
-LABEL operators.openshift.io/valid-subscription="OpenShift Container Platform"
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/

--- a/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-observability-operator.clusterserviceversion.yaml
@@ -88,7 +88,8 @@ metadata:
     capabilities: Basic Install
     olm.skipRange: <0.3.0
     operatorframework.io/suggested-namespace: node-observability-operator
-    operators.openshift.io/valid-subscription: OpenShift Container Platform
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
+      Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.18.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: node-observability-operator.v0.3.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -8,7 +8,6 @@ annotations:
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.18.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-  operators.openshift.io/valid-subscription: "OpenShift Container Platform"
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/manifests/bases/node-observability-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-observability-operator.clusterserviceversion.yaml
@@ -6,7 +6,8 @@ metadata:
     capabilities: Basic Install
     olm.skipRange: <0.3.0
     operatorframework.io/suggested-namespace: node-observability-operator
-    operators.openshift.io/valid-subscription: OpenShift Container Platform
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
+      Container Platform", "OpenShift Platform Plus"]'
   name: node-observability-operator.v0.3.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
This adds the correct label for the csv.

The previous PR's mistakenly used a string and not string array

```
operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
+      Container Platform", "OpenShift Platform Plus"]'
```